### PR TITLE
Wire the frontend into a playable game

### DIFF
--- a/internal/api/games.go
+++ b/internal/api/games.go
@@ -28,18 +28,19 @@ type (
 	}
 
 	gameResponse struct {
-		ID               string             `json:"id"`
-		Started          bool               `json:"started"`
-		Finished         bool               `json:"finished"`
-		Round            int                `json:"round"`
-		CurrentPlayerID  string             `json:"currentPlayerId"`
-		LettersRemaining int                `json:"lettersRemaining"`
-		Players          []playerResponse   `json:"players"`
-		LetterPoints     map[string]int     `json:"letterPoints"`
-		WinnerIDs        []string           `json:"winnerIds,omitempty"`
-		Challenge        *challengeResponse `json:"challenge,omitempty"`
-		PlayerID         string             `json:"playerId"`
-		Rack             []string           `json:"rack,omitempty"`
+		ID                   string             `json:"id"`
+		Started              bool               `json:"started"`
+		Finished             bool               `json:"finished"`
+		Round                int                `json:"round"`
+		CurrentPlayerID      string             `json:"currentPlayerId"`
+		LettersRemaining     int                `json:"lettersRemaining"`
+		Players              []playerResponse   `json:"players"`
+		LetterPoints         map[string]int     `json:"letterPoints"`
+		WinnerIDs            []string           `json:"winnerIds,omitempty"`
+		Challenge            *challengeResponse `json:"challenge,omitempty"`
+		ChallengeableMoverID string             `json:"challengeableMoverId,omitempty"`
+		PlayerID             string             `json:"playerId"`
+		Rack                 []string           `json:"rack,omitempty"`
 	}
 
 	turnResponse struct {
@@ -297,6 +298,10 @@ func constructGameResponse(r *http.Request, game *words.Game) gameResponse {
 	if outcome, pending := game.PendingChallenge(); pending {
 		challenge := constructChallengeResponse(outcome)
 		response.Challenge = &challenge
+	}
+
+	if moverID, challengeable := game.ChallengeableMoverID(); challengeable {
+		response.ChallengeableMoverID = moverID
 	}
 
 	if playerID, identified := playerIDFromRequest(r); identified {

--- a/internal/words/game.go
+++ b/internal/words/game.go
@@ -336,6 +336,16 @@ func (game *Game) assertVoteAllowed(playerID string, vote Vote) error {
 	return nil
 }
 
+// ChallengeableMoverID returns the player whose last word is still open to a
+// challenge, if any.
+func (game *Game) ChallengeableMoverID() (string, bool) {
+	if game.finished || game.challenge != nil || game.lastWord == nil || game.lastWord.settled {
+		return "", false
+	}
+
+	return game.lastWord.playerID, true
+}
+
 // PendingChallenge returns the current tally of the open challenge and
 // whether one is pending.
 func (game *Game) PendingChallenge() (ChallengeOutcome, bool) {

--- a/site/src/lib/Board.svelte
+++ b/site/src/lib/Board.svelte
@@ -7,6 +7,9 @@
         letterPoints?: Record<string, number>;
         cells: Cell[];
         requestCells?: (x1: number, y1: number, x2: number, y2: number) => void;
+        onCellTap?: (x: number, y: number) => void;
+        ghostCells?: Cell[];
+        highlightCell?: { x: number; y: number } | null;
         width: number;
         height: number;
         scale?: number;
@@ -21,6 +24,9 @@
         letterPoints = {},
         cells = [],
         requestCells = (x1, y1, x2, y2) => console.log(x1, y1, x2, y2),
+        onCellTap,
+        ghostCells = [],
+        highlightCell = null,
         width,
         height,
         scale: initialScale = 1,
@@ -46,6 +52,7 @@
     function handlePointerDown(e: PointerEvent) {
         if (disabled) return;
         anchor = { x: e.offsetX, y: e.offsetY };
+        (e.currentTarget as SVGElement).setPointerCapture?.(e.pointerId);
     }
 
     function handlePointerMove(e: PointerEvent) {
@@ -55,12 +62,23 @@
         }
     }
 
-    function handlePointerUp() {
+    function handlePointerUp(e?: PointerEvent) {
+        // a pointer that barely moved is a tap on a cell, not a pan
+        const wasTap = e && anchor
+            && Math.abs(displacementX) < 8
+            && Math.abs(displacementY) < 8;
+
         anchor = null;
         offsetX += displacementX;
         offsetY += displacementY;
         displacementX = 0;
         displacementY = 0;
+
+        if (wasTap && onCellTap) {
+            const cellX = Math.floor((offsetX + e.offsetX) / scale / cellSize);
+            const cellY = Math.floor((offsetY + e.offsetY) / scale / cellSize);
+            onCellTap(cellX, cellY);
+        }
     }
 
     $effect(() => {
@@ -117,6 +135,7 @@
 <style>
     svg {
         user-select: none;
+        touch-action: none;
         cursor: pointer;
         background-position: var(--offset-x) var(--offset-y);
         background-size: var(--cell-size) var(--cell-size);
@@ -145,8 +164,8 @@
         onpointerdown={handlePointerDown}
         onpointermove={handlePointerMove}
         onpointerup={handlePointerUp}
-        onpointercancel={handlePointerUp}
-        onpointerleave={handlePointerUp}
+        onpointercancel={() => handlePointerUp()}
+        onpointerleave={() => handlePointerUp()}
 >
     <rect
             x={0}
@@ -178,6 +197,31 @@
                 letter={cell.letter}
                 points={letterPoints[cell.letter]}
             />
+        {/if}
+    {/each}
+    {#if highlightCell}
+        <rect
+                x={highlightCell.x*cellSize}
+                y={highlightCell.y*cellSize}
+                width={cellSize}
+                height={cellSize}
+                fill="rgba(37,99,235,0.15)"
+                stroke="rgba(37,99,235,0.6)"
+                stroke-width="2"
+        />
+    {/if}
+    {#each ghostCells as cell (cell)}
+        {#if cell.letter}
+            <g opacity="0.65">
+                <Tile
+                    cellSize={cellSize}
+                    x={cell.x*cellSize}
+                    y={cell.y*cellSize}
+                    letter={cell.letter}
+                    points={letterPoints[cell.letter]}
+                    selected
+                />
+            </g>
         {/if}
     {/each}
 </svg>

--- a/site/src/lib/game.svelte.ts
+++ b/site/src/lib/game.svelte.ts
@@ -11,6 +11,30 @@ export type Cell = {
     letter?: string;
 }
 
+export type Player = {
+    id: string;
+    name: string;
+    score: number;
+}
+
+export type Placement = {
+    x: number;
+    y: number;
+    direction: "HORIZONTAL" | "VERTICAL";
+    word: string;
+    points: number;
+    indirectWords: { x: number; y: number; direction: string; word: string }[] | null;
+}
+
+export type Challenge = {
+    challengerId: string;
+    moverId: string;
+    votesInvalid: number;
+    votesValid: number;
+    votesNeeded: number;
+    eligibleVoters: number;
+}
+
 export  class GameController {
     id = $state<string>("");
 
@@ -58,13 +82,44 @@ export  class GameController {
 
     started = $state<boolean>(false);
 
-    players = $state<{ id: string, name: string }[]>([]);
+    finished = $state<boolean>(false);
 
-    messages = $state<string[]>([]);
+    winnerIds = $state<string[]>([]);
+
+    currentPlayerId = $state<string>("");
+
+    lettersRemaining = $state<number>(0);
+
+    players = $state<Player[]>([]);
+
+    challenge = $state<Challenge | null>(null);
+
+    // the id of the player who played the still-challengeable last word
+    challengeableMoverId = $state<string | null>(null);
+
+    myVote = $state<boolean>(false);
+
+    placements = $state<Placement[]>([]);
+
+    selectedPlacement = $state<number>(0);
+
+    error = $state<string>("");
 
     board = $state<board>({ cells: [] });
 
     letterPoints = $state<{ [letter: string]: number }>({})
+
+    get myTurn() {
+        return this.playerId !== null && this.playerId === this.currentPlayerId;
+    }
+
+    getPlayerById(id: string) {
+        return this.players.find(p => p.id === id);
+    }
+
+    playerName(id: string) {
+        return this.getPlayerById(id)?.name ?? "someone";
+    }
 
     async loadInitialData() {
         let resp = await fetch(`${PUBLIC_API_URL}/api/v1/games/${this.id}`, {
@@ -77,19 +132,37 @@ export  class GameController {
         let data: {
             id: string;
             started: boolean;
-            players: { id: string, name: string }[];
+            finished: boolean;
+            currentPlayerId: string;
+            lettersRemaining: number;
+            winnerIds?: string[];
+            challenge?: Challenge;
+            challengeableMoverId?: string;
+            players: Player[];
             playerId: string | null;
             rack?: string[];
             letterPoints: { [letter: string]: number };
         } = await resp.json();
 
         this.started = data.started;
-        this.playerId = data.playerId;
+        this.finished = data.finished;
+        this.currentPlayerId = data.currentPlayerId;
+        this.lettersRemaining = data.lettersRemaining;
+        this.winnerIds = data.winnerIds || [];
+        this.challenge = data.challenge || null;
+        this.challengeableMoverId = data.challengeableMoverId || null;
+        this.playerId = data.playerId || null;
         this.letterPoints = data.letterPoints;
         this.rack = data.rack || [];
         this.players = data.players;
 
-        resp = await fetch(`${PUBLIC_API_URL}/api/v1/games/${this.id}/board`, {
+        await this.reloadBoard();
+
+        this.loaded = true;
+    }
+
+    async reloadBoard() {
+        let resp = await fetch(`${PUBLIC_API_URL}/api/v1/games/${this.id}/board`, {
             credentials: "include"
         });
         if (!resp.ok) {
@@ -97,8 +170,6 @@ export  class GameController {
         }
 
         this.board = await resp.json();
-
-        this.loaded = true;
     }
 
     async loadBoard(minX: number, minY: number, maxX: number, maxY: number) {
@@ -111,7 +182,7 @@ export  class GameController {
 
         let { cells } = await resp.json();
 
-        this.board.cells = this.board.cells.concat(cells);
+        this.board.cells = this.board.cells.concat(cells || []);
     }
 
     streamUpdates() {
@@ -119,18 +190,134 @@ export  class GameController {
         let events = new EventSource(`${PUBLIC_API_URL}/api/v1/games/${this.id}/events`, {
             withCredentials: true
         });
-        events.addEventListener("MESSAGE", (e) => {
-            const { playerId, message } = JSON.parse(e.data);
 
-           this.messages.push(`Player ${playerId} says: ${message}`);
-        })
-        events.addEventListener("GAME_STARTED", () => {
+        events.addEventListener("GAME_STARTED", (e) => {
             this.started = true;
+
+            const { letters } = JSON.parse(e.data);
+            if (letters?.length) {
+                this.rack = letters;
+            }
+
+            // the game snapshot changed under us; pick up turn order
+            this.refreshMeta();
+        })
+
+        events.addEventListener("PLAYER_JOINED", (e) => {
+            const { playerId, playerName } = JSON.parse(e.data);
+            if (!this.getPlayerById(playerId)) {
+                this.players.push({ id: playerId, name: playerName, score: 0 });
+            }
+        })
+
+        events.addEventListener("WORD_PLAYED", (e) => {
+            const played: { playerId: string, nextPlayerId: string, points: number } & Placement = JSON.parse(e.data);
+
+            this.mergeWord(played);
+            this.currentPlayerId = played.nextPlayerId;
+            this.challengeableMoverId = played.playerId;
+            this.myVote = false;
+
+            const player = this.getPlayerById(played.playerId);
+            if (player) {
+                player.score += played.points;
+            }
+
+            this.refreshMeta();
+        })
+
+        events.addEventListener("RACK_UPDATED", (e) => {
+            const { letters } = JSON.parse(e.data);
+            this.rack = letters || [];
+        })
+
+        events.addEventListener("TURN_PASSED", (e) => {
+            const { nextPlayerId } = JSON.parse(e.data);
+            this.currentPlayerId = nextPlayerId;
+            this.challengeableMoverId = null;
+            this.refreshMeta();
+        })
+
+        events.addEventListener("LETTERS_EXCHANGED", (e) => {
+            const { nextPlayerId } = JSON.parse(e.data);
+            this.currentPlayerId = nextPlayerId;
+            this.challengeableMoverId = null;
+            this.refreshMeta();
+        })
+
+        events.addEventListener("CHALLENGE_STARTED", (e) => {
+            this.challenge = JSON.parse(e.data);
+        })
+
+        events.addEventListener("CHALLENGE_VOTE_CAST", (e) => {
+            const { votesInvalid, votesValid, votesNeeded } = JSON.parse(e.data);
+            if (this.challenge) {
+                this.challenge = { ...this.challenge, votesInvalid, votesValid, votesNeeded };
+            }
+        })
+
+        events.addEventListener("CHALLENGE_RESOLVED", async (e) => {
+            const { upheld } = JSON.parse(e.data);
+            this.challenge = null;
+            this.challengeableMoverId = null;
+            this.myVote = false;
+
+            if (upheld) {
+                // the word came off the board; scores changed too
+                await this.reloadBoard();
+            }
+            await this.refreshMeta();
+        })
+
+        events.addEventListener("GAME_ENDED", (e) => {
+            const { winnerIds, scores } = JSON.parse(e.data);
+            this.finished = true;
+            this.winnerIds = winnerIds || [];
+            for (const player of this.players) {
+                if (scores && player.id in scores) {
+                    player.score = scores[player.id];
+                }
+            }
         })
     }
 
-    getPlayerById(id: string) {
-        return this.players.find(p => p.id === id);
+    // refreshMeta re-syncs scores, pool size, and turn from the server. It's
+    // cheap and keeps locally-tracked numbers honest.
+    async refreshMeta() {
+        let resp = await fetch(`${PUBLIC_API_URL}/api/v1/games/${this.id}`, {
+            credentials: "include"
+        });
+        if (!resp.ok) {
+            return;
+        }
+
+        const data = await resp.json();
+        this.players = data.players;
+        this.currentPlayerId = data.currentPlayerId;
+        this.lettersRemaining = data.lettersRemaining;
+        this.finished = data.finished;
+        this.winnerIds = data.winnerIds || [];
+        this.challenge = data.challenge || null;
+        this.challengeableMoverId = data.challengeableMoverId || null;
+    }
+
+    mergeWord(placement: Placement) {
+        const cells = [...this.board.cells];
+        const letters = [...placement.word];
+
+        for (let i = 0; i < letters.length; i++) {
+            const x = placement.direction === "HORIZONTAL" ? placement.x + i : placement.x;
+            const y = placement.direction === "VERTICAL" ? placement.y + i : placement.y;
+
+            const existing = cells.find(cell => cell.x === x && cell.y === y);
+            if (existing) {
+                existing.letter = letters[i];
+            } else {
+                cells.push({ x, y, letter: letters[i] });
+            }
+        }
+
+        this.board = { cells };
     }
 
     async join(name: string) {
@@ -161,6 +348,7 @@ export  class GameController {
 
     async start() {
         let resp = await fetch(`${PUBLIC_API_URL}/api/v1/games/${this.id}`, {
+            credentials: "include",
             method: "PATCH",
             headers: {
                 "Content-Type": "application/json"
@@ -179,5 +367,114 @@ export  class GameController {
 
         this.started = started;
         this.rack = rack;
+        await this.refreshMeta();
+    }
+
+    async findPlacements(x: number, y: number) {
+        this.error = "";
+        this.placements = [];
+        this.selectedPlacement = 0;
+
+        let resp = await fetch(`${PUBLIC_API_URL}/api/v1/games/${this.id}/board/placements?x=${x}&y=${y}&word=${encodeURIComponent(this.input)}`, {
+            credentials: "include"
+        });
+
+        if (!resp.ok) {
+            this.error = await this.errorMessage(resp, "That word can't go there.");
+            return;
+        }
+
+        this.placements = await resp.json();
+    }
+
+    clearPlacements() {
+        this.placements = [];
+        this.selectedPlacement = 0;
+        this.error = "";
+    }
+
+    async playSelectedPlacement() {
+        const placement = this.placements[this.selectedPlacement];
+        if (!placement) return;
+
+        let resp = await fetch(`${PUBLIC_API_URL}/api/v1/games/${this.id}/board`, {
+            credentials: "include",
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({
+                operation: "ADD_WORD",
+                payload: {
+                    x: placement.x,
+                    y: placement.y,
+                    direction: placement.direction,
+                    word: placement.word,
+                }
+            })
+        });
+
+        if (!resp.ok) {
+            this.error = await this.errorMessage(resp, "Couldn't play that word.");
+            return;
+        }
+
+        // board, rack, scores, and turn all update via events
+        this.input = "";
+        this.clearPlacements();
+    }
+
+    async updateGame(operation: string, payload?: object) {
+        this.error = "";
+
+        let resp = await fetch(`${PUBLIC_API_URL}/api/v1/games/${this.id}`, {
+            credentials: "include",
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({ operation, payload })
+        });
+
+        if (!resp.ok) {
+            this.error = await this.errorMessage(resp, "That didn't work.");
+            return null;
+        }
+
+        return await resp.json();
+    }
+
+    async pass() {
+        await this.updateGame("PASS_TURN");
+    }
+
+    async exchange(letters: string[]) {
+        const result = await this.updateGame("EXCHANGE_LETTERS", { letters });
+        if (result) {
+            this.input = "";
+        }
+    }
+
+    async challengeWord() {
+        const result = await this.updateGame("CHALLENGE_WORD");
+        if (result) {
+            this.myVote = true;
+        }
+    }
+
+    async castVote(vote: "VALID" | "INVALID") {
+        const result = await this.updateGame("CAST_VOTE", { vote });
+        if (result) {
+            this.myVote = true;
+        }
+    }
+
+    async errorMessage(resp: Response, fallback: string) {
+        try {
+            const { error } = await resp.json();
+            return error || fallback;
+        } catch {
+            return fallback;
+        }
     }
 }

--- a/site/src/routes/play/+page.svelte
+++ b/site/src/routes/play/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import {GameController} from '$lib/game.svelte.ts';
+    import {GameController} from '$lib/game.svelte';
     import { page } from '$app/stores';
     import {onMount} from "svelte";
     import Board from "$lib/Board.svelte";
@@ -41,8 +41,79 @@
     let name = $state("");
 
     $effect(() => {
-        game.input = game.input.toUpperCase();
+        game.input = game.input.toUpperCase().replace(/[^A-Z]/g, "");
     })
+
+    let selectedCell = $state<{ x: number; y: number } | null>(null);
+
+    async function handleCellTap(x: number, y: number) {
+        if (!game.started || game.finished || !game.myTurn || game.challenge) {
+            return;
+        }
+
+        if (!game.input) {
+            game.error = "Type a word first, then tap where it goes.";
+            return;
+        }
+
+        selectedCell = { x, y };
+        await game.findPlacements(x, y);
+
+        if (game.placements.length === 0 && !game.error) {
+            game.error = "That word doesn't fit there.";
+            selectedCell = null;
+        }
+    }
+
+    function cancelPlacement() {
+        selectedCell = null;
+        game.clearPlacements();
+    }
+
+    async function playWord() {
+        await game.playSelectedPlacement();
+        if (!game.error) {
+            selectedCell = null;
+        }
+    }
+
+    // ghost tiles previewing the currently selected placement option;
+    // letters already on the board are left out
+    let ghostCells = $derived.by(() => {
+        const placement = game.placements[game.selectedPlacement];
+        if (!placement) return [];
+
+        const ghosts = [];
+        for (let i = 0; i < placement.word.length; i++) {
+            const x = placement.direction === "HORIZONTAL" ? placement.x + i : placement.x;
+            const y = placement.direction === "VERTICAL" ? placement.y + i : placement.y;
+
+            const occupied = game.board.cells.some(cell => cell.x === x && cell.y === y && cell.letter);
+            if (!occupied) {
+                ghosts.push({ x, y, letter: placement.word[i] });
+            }
+        }
+
+        return ghosts;
+    });
+
+    let selectedPlacement = $derived(game.placements[game.selectedPlacement]);
+
+    let canChallenge = $derived(
+        game.started
+        && !game.finished
+        && !game.challenge
+        && game.challengeableMoverId !== null
+        && game.challengeableMoverId !== game.playerId
+    );
+
+    let canVote = $derived(
+        game.challenge !== null
+        && !game.myVote
+        && game.playerId !== null
+        && game.playerId !== game.challenge?.moverId
+        && game.playerId !== game.challenge?.challengerId
+    );
 </script>
 
 <svelte:window onresize={applyWindowSize} />
@@ -51,15 +122,6 @@
 </svelte:head>
 
 <style>
-    main {
-        padding: 0;
-        max-width: 960px;
-        margin: 0 auto;
-        display: flex;
-        flex-direction: column;
-        height: 100%;
-    }
-
     .panel {
         display: flex;
         flex-direction: column;
@@ -71,6 +133,7 @@
         backdrop-filter: blur(10px);
         box-shadow: 0 0 10px rgba(0,0,0,0.1);
         padding: 1rem;
+        gap: 0.5rem;
     }
 
     input {
@@ -94,11 +157,113 @@
 
     header {
         top: 0;
+        padding: 0.5rem 1rem;
     }
 
     footer {
         bottom: 0;
         justify-content: center;
+    }
+
+    .scores {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 0.25rem 1rem;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        font-size: 0.9rem;
+    }
+
+    .scores .current {
+        font-weight: bold;
+    }
+
+    .status {
+        margin: 0;
+        font-size: 0.85rem;
+        color: rgba(0,0,0,0.6);
+    }
+
+    .actions {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 0.5rem;
+    }
+
+    .actions button {
+        font: inherit;
+        font-size: 0.9rem;
+        padding: 0.4rem 0.9rem;
+        border-radius: 0.5rem;
+        border: 1px solid rgba(0,0,0,0.25);
+        background-color: rgba(255,255,255,0.85);
+        cursor: pointer;
+    }
+
+    .actions button.primary {
+        background-color: #2563eb;
+        border-color: #2563eb;
+        color: white;
+    }
+
+    .actions button:disabled {
+        opacity: 0.5;
+        cursor: default;
+    }
+
+    .error {
+        margin: 0;
+        color: #b91c1c;
+        font-size: 0.9rem;
+        text-align: center;
+    }
+
+    .hint {
+        margin: 0;
+        font-size: 0.85rem;
+        color: rgba(0,0,0,0.55);
+        text-align: center;
+    }
+
+    .challenge {
+        text-align: center;
+        font-size: 0.9rem;
+    }
+
+    .challenge p {
+        margin: 0 0 0.5rem;
+    }
+
+    .gameover {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background-color: rgba(255,255,255,0.75);
+        backdrop-filter: blur(4px);
+    }
+
+    .gameover > div {
+        background: white;
+        border-radius: 1rem;
+        box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+        padding: 2rem;
+        text-align: center;
+        max-width: 20rem;
+    }
+
+    .gameover h2 {
+        margin-top: 0;
+    }
+
+    .gameover ol {
+        list-style: none;
+        margin: 0;
+        padding: 0;
     }
 </style>
 
@@ -108,6 +273,9 @@
     <Board
             cells={[...game.board.cells]}
             requestCells={(x1, y1, x2, y2) => game.loadBoard(x1, y1, x2, y2)}
+            onCellTap={handleCellTap}
+            ghostCells={ghostCells}
+            highlightCell={selectedCell}
             width={boardWidth}
             height={boardHeight}
             offsetX={offsetX}
@@ -116,7 +284,30 @@
             style="position: fixed; top: 0; left: 0; width: 100%; height: 100%;"
             cellSize={50}
     />
-    <div class="panel">
+
+    {#if game.started}
+        <header class="panel">
+            <ul class="scores">
+                {#each game.players as player (player.id)}
+                    <li class:current={player.id === game.currentPlayerId}>
+                        {player.name}{player.id === game.playerId ? " (you)" : ""}: {player.score}
+                    </li>
+                {/each}
+            </ul>
+            {#if !game.finished}
+                <p class="status">
+                    {game.myTurn ? "Your turn" : `${game.playerName(game.currentPlayerId)}'s turn`}
+                    · {game.lettersRemaining} letters left
+                </p>
+            {/if}
+        </header>
+    {/if}
+
+    <footer class="panel">
+        {#if game.error}
+            <p class="error">{game.error}</p>
+        {/if}
+
         {#if !game.playerId}
             <div>
                 <label>
@@ -126,21 +317,88 @@
 
                 <button class="button" onclick={async () => await game.join(name)}>Join game</button>
             </div>
-        {:else}
-            {#if game.started}
-                <div>
-                    <Rack letters={game.sortedRack} letterPoints={game.letterPoints} input={game.input} />
-                    <input type="text" bind:value={game.input} placeholder="WORD" class="input" />
-                </div>
-            {:else}
-                <div>
-                    <button class="button" onclick={(e) => {
-                        e.preventDefault();
+        {:else if !game.started}
+            <div class="actions">
+                <button class="primary" onclick={(e) => {
+                    e.preventDefault();
 
-                        game.start();
-                    }}>Start game</button>
-                </div>
-            {/if}
+                    game.start();
+                }}>Start game</button>
+            </div>
+            <p class="hint">Waiting for players... share this page's link to invite them.</p>
+        {:else if game.challenge}
+            <div class="challenge">
+                <p>
+                    <strong>{game.playerName(game.challenge.challengerId)}</strong> challenged
+                    <strong>{game.playerName(game.challenge.moverId)}</strong>'s word!
+                    ({game.challenge.votesInvalid + game.challenge.votesValid} of {game.challenge.eligibleVoters} votes in)
+                </p>
+                {#if canVote}
+                    <div class="actions">
+                        <button onclick={() => game.castVote("VALID")}>Real word</button>
+                        <button onclick={() => game.castVote("INVALID")}>Not a word</button>
+                    </div>
+                {:else}
+                    <p class="hint">Waiting for votes...</p>
+                {/if}
+            </div>
+        {:else if selectedPlacement}
+            <div class="actions">
+                {#if game.placements.length > 1}
+                    <button onclick={() => game.selectedPlacement = (game.selectedPlacement + game.placements.length - 1) % game.placements.length}>&larr;</button>
+                {/if}
+                <button class="primary" onclick={playWord}>
+                    Play {selectedPlacement.word} for {selectedPlacement.points} pts
+                    {#if game.placements.length > 1}
+                        ({game.selectedPlacement + 1}/{game.placements.length})
+                    {/if}
+                </button>
+                {#if game.placements.length > 1}
+                    <button onclick={() => game.selectedPlacement = (game.selectedPlacement + 1) % game.placements.length}>&rarr;</button>
+                {/if}
+                <button onclick={cancelPlacement}>Cancel</button>
+            </div>
+        {:else}
+            <div style="width: 100%; max-width: 24rem;">
+                <Rack letters={game.sortedRack} letterPoints={game.letterPoints} input={game.input} />
+                {#if game.myTurn}
+                    <input type="text" bind:value={game.input} placeholder="WORD" class="input" />
+                    <p class="hint">Type a word, then tap the square where it starts.</p>
+                {/if}
+            </div>
+            <div class="actions">
+                {#if game.myTurn}
+                    <button onclick={() => game.pass()}>Pass</button>
+                    <button
+                            disabled={game.input.length === 0}
+                            onclick={() => game.exchange([...game.input])}
+                    >Exchange{game.input.length > 0 ? ` ${game.input.length}` : ""}</button>
+                {/if}
+                {#if canChallenge}
+                    <button onclick={() => game.challengeWord()}>Challenge last word</button>
+                {/if}
+            </div>
         {/if}
-    </div>
+    </footer>
+
+    {#if game.finished}
+        <div class="gameover">
+            <div>
+                <h2>
+                    {#if game.winnerIds.length === 1}
+                        {game.playerName(game.winnerIds[0])} wins!
+                    {:else if game.winnerIds.length > 1}
+                        It's a tie!
+                    {:else}
+                        Game over
+                    {/if}
+                </h2>
+                <ol>
+                    {#each [...game.players].sort((a, b) => b.score - a.score) as player (player.id)}
+                        <li>{player.name}: {player.score}</li>
+                    {/each}
+                </ol>
+            </div>
+        </div>
+    {/if}
 {/if}


### PR DESCRIPTION
## Summary

The backend (merged in #3) could run a full game, but the SvelteKit app never called the placement or play endpoints — you could load a game and join, but not actually play. This wires the frontend into the full API so the game is playable multiplayer, live.

## Changes

**`site/src/lib/game.svelte.ts`** — the `GameController` now covers the whole API:
- Placement flow: `findPlacements(x, y)` against `GET /board/placements`, placement selection, and `playSelectedPlacement()` via `ADD_WORD`
- Actions: pass, exchange, challenge, and vote via the game `PATCH` operations
- Live updates: handlers for every SSE event type (`WORD_PLAYED`, `RACK_UPDATED`, `TURN_PASSED`, `LETTERS_EXCHANGED`, `CHALLENGE_STARTED`/`VOTE_CAST`/`RESOLVED`, `GAME_ENDED`, ...) so boards, racks, scores, and turns update for everyone without refreshing
- Server error messages surfaced through a reactive `error` field

**`site/src/lib/Board.svelte`**:
- Tap-vs-drag detection: a pointer that barely moves selects the cell under it (`onCellTap`), while panning still works; `touch-action: none` + pointer capture make this work on mobile (relates to #1)
- Ghost tiles previewing the currently selected placement option, plus a highlight on the tapped anchor cell

**`site/src/routes/play/+page.svelte`** — the full play loop:
- Type a word, tap the square where it goes, cycle through placement options (with live board previews and point totals), then play
- Turn/score/letters-remaining header, pass and exchange buttons, challenge button during the challenge window, and voting UI during an open challenge
- Winner overlay when the game ends, inline error display

**Backend (small)** — `GET /api/v1/games/{id}` now includes `challengeableMoverId` so the challenge window survives a page refresh, backed by a new `Game.ChallengeableMoverID()` accessor.

## Testing

- `go build ./... && go vet ./... && go test ./...` green
- `npm run build` (with `PUBLIC_API_URL` as in the Dockerfile) builds clean; `svelte-check` reports no new issues in touched files
- End-to-end smoke test against a running server: create → join ×2 → start → find placements → play a word → verified `challengeableMoverId` and turn advance in the game response

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxiAE56JC7irn2xg1rZNqQ)_