### PR TITLE
Fix board taps landing on child shapes and null fields on fresh games

### DIFF
--- a/internal/api/board.go
+++ b/internal/api/board.go
@@ -181,7 +181,7 @@ func constructPlacementResponse(result words.PlacementResult) placementResponse 
 }
 
 func boardCells(board *words.Board, area extents) []cellResponse {
-	var cells []cellResponse
+	cells := []cellResponse{}
 
 	for row := area.minY; row <= area.maxY; row++ {
 		for column := area.minX; column <= area.maxX; column++ {

--- a/internal/api/games.go
+++ b/internal/api/games.go
@@ -315,7 +315,7 @@ func constructGameResponse(r *http.Request, game *words.Game) gameResponse {
 }
 
 func constructPlayerResponses(game *words.Game) []playerResponse {
-	var players []playerResponse
+	players := []playerResponse{}
 	for _, player := range game.Players() {
 		players = append(players, playerResponse{
 			ID:    player.ID(),

--- a/site/src/lib/Board.svelte
+++ b/site/src/lib/Board.svelte
@@ -49,16 +49,26 @@
     let maxX = $derived(Math.max(...cells.map(cell => cell.x)));
     let maxY = $derived(Math.max(...cells.map(cell => cell.y)));
 
+    let svgElement: SVGSVGElement;
+
+    // offsetX/offsetY are relative to the event target, which can be a tile
+    // or the center star rather than the svg - measure against the svg itself
+    function pointerPosition(e: PointerEvent) {
+        const rect = svgElement.getBoundingClientRect();
+        return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    }
+
     function handlePointerDown(e: PointerEvent) {
         if (disabled) return;
-        anchor = { x: e.offsetX, y: e.offsetY };
-        (e.currentTarget as SVGElement).setPointerCapture?.(e.pointerId);
+        anchor = pointerPosition(e);
+        svgElement.setPointerCapture?.(e.pointerId);
     }
 
     function handlePointerMove(e: PointerEvent) {
         if (anchor) {
-            displacementX = anchor.x - e.offsetX;
-            displacementY =  anchor.y - e.offsetY;
+            const position = pointerPosition(e);
+            displacementX = anchor.x - position.x;
+            displacementY = anchor.y - position.y;
         }
     }
 
@@ -75,8 +85,9 @@
         displacementY = 0;
 
         if (wasTap && onCellTap) {
-            const cellX = Math.floor((offsetX + e.offsetX) / scale / cellSize);
-            const cellY = Math.floor((offsetY + e.offsetY) / scale / cellSize);
+            const position = pointerPosition(e);
+            const cellX = Math.floor((offsetX + position.x) / scale / cellSize);
+            const cellY = Math.floor((offsetY + position.y) / scale / cellSize);
             onCellTap(cellX, cellY);
         }
     }
@@ -133,6 +144,10 @@
 </script>
 
 <style>
+    svg :global(*) {
+        pointer-events: none;
+    }
+
     svg {
         user-select: none;
         touch-action: none;
@@ -157,6 +172,7 @@
 </style>
 
 <svg
+        bind:this={svgElement}
         style="--cell-size: {cellSize*scale}px; --offset-x: {Math.round((-offsetX-displacementX-0.5)%cellSize*precision)/precision}px; --offset-y: {Math.round((-offsetY-displacementY-0.5)%cellSize*precision)/precision}px;{style}"
         viewBox={`${Math.round((offsetX+displacementX) / scale * precision) / precision} ${Math.round((offsetY+displacementY) / scale * precision) / precision} ${Math.round(width / scale * precision) / precision} ${Math.round(height / scale*precision)/precision}`}
         width={width}

--- a/site/src/lib/game.svelte.ts
+++ b/site/src/lib/game.svelte.ts
@@ -154,7 +154,7 @@ export  class GameController {
         this.playerId = data.playerId || null;
         this.letterPoints = data.letterPoints;
         this.rack = data.rack || [];
-        this.players = data.players;
+        this.players = data.players || [];
 
         await this.reloadBoard();
 
@@ -169,7 +169,8 @@ export  class GameController {
             throw new Error(`Failed to fetch board for game ${this.id}`);
         }
 
-        this.board = await resp.json();
+        const { cells } = await resp.json();
+        this.board = { cells: cells || [] };
     }
 
     async loadBoard(minX: number, minY: number, maxX: number, maxY: number) {
@@ -292,7 +293,7 @@ export  class GameController {
         }
 
         const data = await resp.json();
-        this.players = data.players;
+        this.players = data.players || [];
         this.currentPlayerId = data.currentPlayerId;
         this.lettersRemaining = data.lettersRemaining;
         this.finished = data.finished;
@@ -343,7 +344,7 @@ export  class GameController {
         let { playerId, players } = await resp.json();
 
         this.playerId = playerId;
-        this.players = players;
+        this.players = players || [];
     }
 
     async start() {

--- a/site/src/routes/play/+page.svelte
+++ b/site/src/routes/play/+page.svelte
@@ -47,7 +47,12 @@
     let selectedCell = $state<{ x: number; y: number } | null>(null);
 
     async function handleCellTap(x: number, y: number) {
-        if (!game.started || game.finished || !game.myTurn || game.challenge) {
+        if (!game.started || game.finished || game.challenge) {
+            return;
+        }
+
+        if (!game.myTurn) {
+            game.error = `It's ${game.playerName(game.currentPlayerId)}'s turn.`;
             return;
         }
 
@@ -363,7 +368,13 @@
                 <Rack letters={game.sortedRack} letterPoints={game.letterPoints} input={game.input} />
                 {#if game.myTurn}
                     <input type="text" bind:value={game.input} placeholder="WORD" class="input" />
-                    <p class="hint">Type a word, then tap the square where it starts.</p>
+                    <p class="hint">
+                        {#if game.board.cells.some(cell => cell.letter)}
+                            Type a word, then tap the square where it starts.
+                        {:else}
+                            Type a word, then tap the center star to place it.
+                        {/if}
+                    </p>
                 {/if}
             </div>
             <div class="actions">


### PR DESCRIPTION
## Summary

Fixes the "typed a word, tapped, nothing happened" bug from playtesting — placing the **first word was impossible**.

## The tap bug

`PointerEvent.offsetX/offsetY` are relative to the event **target**, not the listener. When a tap landed on the center star, a tile, or a modifier square, the pointer-down coordinates were child-relative while later events (retargeted by pointer capture) were svg-relative. The math saw a phantom drag of hundreds of pixels, classified the tap as a pan, and dropped it. Since the first word must cross the center star, tapping it hit this every time.

Fix in `site/src/lib/Board.svelte`:
- Pointer positions are now computed from `clientX/clientY` against the svg's `getBoundingClientRect()`, so every event uses the same coordinate space
- Child shapes get `pointer-events: none` so the svg is always the event target

## Fresh-game null crash (found while verifying)

A newly created game returned `"players": null` and an empty board returned `"cells": null`. The SSE `PLAYER_JOINED` handler crashed calling `.find` on the null players list before the first join response arrived. Fixed on both sides:
- API now returns `[]` for empty players/cells (`internal/api/games.go`, `internal/api/board.go`)
- The controller guards every list field with `|| []` regardless

## UX polish

- Tapping while it's not your turn now says whose turn it is instead of doing nothing silently
- On an empty board the hint says to tap the center star

## Testing

- `go vet` / `go test ./...` green; fresh-game response verified to return `players: []`
- Scripted Chromium session against the real server: two players join, the active player types a word, **taps the center star**, placement options appear ("Play ZJ for 18 pts (1/4)"), plays it, and the word appears live on the other player's board via SSE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxiAE56JC7irn2xg1rZNqQ)_