### PR TITLE
Playtest feedback: zoom, missed events, interactive rack, persistence

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,10 +2,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/carterjs/words/internal/api"
 	"github.com/carterjs/words/internal/pubsub"
@@ -13,13 +15,24 @@ import (
 	"github.com/carterjs/words/internal/words"
 )
 
+const (
+	// cleanupInterval is how often idle games are swept.
+	cleanupInterval = time.Hour
+	// maxGameIdle is how long an unfinished game may go without a save
+	// before it is deleted. Finished games are kept.
+	maxGameIdle = 14 * 24 * time.Hour
+)
+
 func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	port := envOrDefault("PORT", "8080")
 
+	fileStore := store.NewFS(envOrDefault("DATA_DIR", "/tmp/word-game"))
+	go removeIdleGames(fileStore, logger)
+
 	service := words.NewService(
-		store.NewFS(envOrDefault("DATA_DIR", "/tmp/word-game")),
+		fileStore,
 		pubsub.NewGameBroker(),
 		logger,
 	)
@@ -32,6 +45,20 @@ func main() {
 	logger.Info("starting server", "port", port)
 	if err := http.ListenAndServe(":"+port, server.Handler()); err != nil {
 		panic(fmt.Sprintf("server stopped: %v", err))
+	}
+}
+
+// removeIdleGames periodically deletes unfinished games that have gone stale.
+func removeIdleGames(fileStore *store.FS, logger *slog.Logger) {
+	for {
+		removed, err := fileStore.RemoveIdleGames(context.Background(), maxGameIdle)
+		if err != nil {
+			logger.Error("cleaning up idle games", "error", err)
+		} else if removed > 0 {
+			logger.Info("cleaned up idle games", "count", removed)
+		}
+
+		time.Sleep(cleanupInterval)
 	}
 }
 

--- a/fly.toml
+++ b/fly.toml
@@ -4,14 +4,15 @@
 #
 
 app = 'words-game'
-primary_region = 'den'
+# the words_data volume lives in dfw; machines must be in the volume's region
+primary_region = 'dfw'
 
 [build]
 
 [env]
   DATA_DIR = '/data'
 
-# requires a one-time `fly volumes create words_data --region den --size 1`
+# requires the one-time `fly volumes create words_data --region dfw --size 1`
 [mounts]
   source = 'words_data'
   destination = '/data'

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,14 @@ primary_region = 'den'
 
 [build]
 
+[env]
+  DATA_DIR = '/data'
+
+# requires a one-time `fly volumes create words_data --region den --size 1`
+[mounts]
+  source = 'words_data'
+  destination = '/data'
+
 [http_service]
   internal_port = 8080
   force_https = true

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -1,10 +1,17 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"time"
 )
+
+// keepaliveInterval is how often a comment is written to an otherwise quiet
+// event stream so proxies don't drop the connection as idle.
+const keepaliveInterval = 25 * time.Second
 
 // handleStreamGameEvents streams a game's events over server-sent events.
 // Players identified by their cookie also receive their private events.
@@ -29,9 +36,21 @@ func (server *Server) handleStreamGameEvents() http.HandlerFunc {
 		}
 
 		for {
-			event, err := subscription.Next(r.Context())
+			waitCtx, cancel := context.WithTimeout(r.Context(), keepaliveInterval)
+			event, err := subscription.Next(waitCtx)
+			cancel()
+
 			if err != nil {
-				return
+				if r.Context().Err() != nil || !errors.Is(err, context.DeadlineExceeded) {
+					return
+				}
+
+				// quiet stretch: write a comment so the connection stays alive
+				fmt.Fprint(w, ": keepalive\n\n")
+				if canFlush {
+					flusher.Flush()
+				}
+				continue
 			}
 
 			payload := event.Payload

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -22,6 +22,12 @@ func (server *Server) handleStreamGameEvents() http.HandlerFunc {
 
 		flusher, canFlush := w.(http.Flusher)
 
+		// flush the headers right away so clients see the stream as open and
+		// can catch up on state missed while (re)connecting
+		if canFlush {
+			flusher.Flush()
+		}
+
 		for {
 			event, err := subscription.Next(r.Context())
 			if err != nil {

--- a/internal/store/file.go
+++ b/internal/store/file.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/carterjs/words/internal/words"
 )
@@ -88,6 +90,48 @@ func (fileStore *FS) GameByID(ctx context.Context, gameID string) (*words.Game, 
 	return game, nil
 }
 
+// gameFileSuffix is the extension of stored game snapshots.
+const gameFileSuffix = ".json.gz"
+
+// RemoveIdleGames deletes unfinished games that have not been saved for at
+// least maxIdle, returning how many were removed. Finished games are kept so
+// they can be displayed later. A game's last save time is its file's
+// modification time.
+func (fileStore *FS) RemoveIdleGames(ctx context.Context, maxIdle time.Duration) (int, error) {
+	entries, err := os.ReadDir(fileStore.directory)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+
+		return 0, fmt.Errorf("reading games directory: %w", err)
+	}
+
+	var removed int
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), gameFileSuffix) {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil || time.Since(info.ModTime()) < maxIdle {
+			continue
+		}
+
+		game, err := fileStore.GameByID(ctx, strings.TrimSuffix(entry.Name(), gameFileSuffix))
+		if err != nil || game.Finished() {
+			continue
+		}
+
+		if err := os.Remove(filepath.Join(fileStore.directory, entry.Name())); err != nil {
+			return removed, fmt.Errorf("removing idle game: %w", err)
+		}
+		removed++
+	}
+
+	return removed, nil
+}
+
 func (fileStore *FS) gameFile(gameID string) string {
-	return filepath.Join(fileStore.directory, gameID+".json.gz")
+	return filepath.Join(fileStore.directory, gameID+gameFileSuffix)
 }

--- a/internal/store/file_test.go
+++ b/internal/store/file_test.go
@@ -1,7 +1,10 @@
 package store_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/carterjs/words/internal/store"
 	"github.com/carterjs/words/internal/words"
@@ -41,6 +44,58 @@ func TestFS_GameByID(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, game.State(), loaded.State())
+		})
+	}
+}
+
+func TestFS_RemoveIdleGames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		finished    bool
+		old         bool
+		wantRemoved int
+	}{
+		{name: "removes an idle unfinished game", old: true, wantRemoved: 1},
+		{name: "keeps an idle finished game", old: true, finished: true},
+		{name: "keeps a recently saved game"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			directory := t.TempDir()
+			fileStore := store.NewFS(directory)
+
+			game := newSavableGame(t)
+			if test.finished {
+				state := game.State()
+				state.Finished = true
+
+				var err error
+				game, err = words.NewGameFromState(state)
+				require.NoError(t, err)
+			}
+			require.NoError(t, fileStore.SaveGame(t.Context(), game))
+
+			if test.old {
+				stale := time.Now().Add(-48 * time.Hour)
+				require.NoError(t, os.Chtimes(filepath.Join(directory, game.ID()+".json.gz"), stale, stale))
+			}
+
+			removed, err := fileStore.RemoveIdleGames(t.Context(), 24*time.Hour)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.wantRemoved, removed)
+
+			_, err = fileStore.GameByID(t.Context(), game.ID())
+			if test.wantRemoved > 0 {
+				assert.ErrorIs(t, err, words.ErrGameNotFound)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/site/src/lib/Board.svelte
+++ b/site/src/lib/Board.svelte
@@ -90,7 +90,11 @@
         if (disabled) return;
         const position = pointerPosition(e);
         pointers.set(e.pointerId, position);
-        svgElement.setPointerCapture?.(e.pointerId);
+        try {
+            svgElement.setPointerCapture?.(e.pointerId);
+        } catch {
+            // synthetic events have no active pointer to capture
+        }
 
         if (pointers.size === 2) {
             // second finger down: commit any in-progress pan, start pinching

--- a/site/src/lib/Board.svelte
+++ b/site/src/lib/Board.svelte
@@ -10,6 +10,7 @@
         onCellTap?: (x: number, y: number) => void;
         ghostCells?: Cell[];
         highlightCell?: { x: number; y: number } | null;
+        highlightCells?: { x: number; y: number }[];
         width: number;
         height: number;
         scale?: number;
@@ -27,6 +28,7 @@
         onCellTap,
         ghostCells = [],
         highlightCell = null,
+        highlightCells = [],
         width,
         height,
         scale: initialScale = 1,
@@ -76,6 +78,12 @@
 
     function clampScale(value: number) {
         return Math.min(maxScale, Math.max(minScale, value));
+    }
+
+    // centerOn pans the view so the given cell sits at the center of the board
+    export function centerOn(cellX: number, cellY: number) {
+        offsetX = (cellX + 0.5) * cellSize * scale - width / 2;
+        offsetY = (cellY + 0.5) * cellSize * scale - height / 2;
     }
 
     // zoomTo changes the scale while keeping the board point under the given
@@ -305,6 +313,18 @@
                 points={letterPoints[cell.letter]}
             />
         {/if}
+    {/each}
+    {#each highlightCells as cell (cell)}
+        <rect
+                class="highlight"
+                x={cell.x*cellSize}
+                y={cell.y*cellSize}
+                width={cellSize}
+                height={cellSize}
+                fill="rgba(37,99,235,0.18)"
+                stroke="rgba(37,99,235,0.4)"
+                stroke-width="1.5"
+        />
     {/each}
     {#if highlightCell}
         <rect

--- a/site/src/lib/Board.svelte
+++ b/site/src/lib/Board.svelte
@@ -39,6 +39,9 @@
 
     let scale = $state(initialScale)
 
+    const minScale = 0.35;
+    const maxScale = 2.5;
+
     let anchor: null | { x: number; y: number } = null;
 
     let displacementX = $state(0);
@@ -53,28 +56,90 @@
 
     // offsetX/offsetY are relative to the event target, which can be a tile
     // or the center star rather than the svg - measure against the svg itself
-    function pointerPosition(e: PointerEvent) {
+    function pointerPosition(e: { clientX: number; clientY: number }) {
         const rect = svgElement.getBoundingClientRect();
         return { x: e.clientX - rect.left, y: e.clientY - rect.top };
     }
 
+    let pointers = new Map<number, { x: number; y: number }>();
+    let pinched = false;
+
+    function pointerDistance() {
+        const [first, second] = [...pointers.values()];
+        return Math.hypot(first.x - second.x, first.y - second.y);
+    }
+
+    function pointerMidpoint() {
+        const [first, second] = [...pointers.values()];
+        return { x: (first.x + second.x) / 2, y: (first.y + second.y) / 2 };
+    }
+
+    function clampScale(value: number) {
+        return Math.min(maxScale, Math.max(minScale, value));
+    }
+
+    // zoomTo changes the scale while keeping the board point under the given
+    // screen position fixed (and optionally following it to a new position)
+    function zoomTo(nextScale: number, from: { x: number; y: number }, to = from) {
+        offsetX = (offsetX + from.x) * (nextScale / scale) - to.x;
+        offsetY = (offsetY + from.y) * (nextScale / scale) - to.y;
+        scale = nextScale;
+    }
+
     function handlePointerDown(e: PointerEvent) {
         if (disabled) return;
-        anchor = pointerPosition(e);
+        const position = pointerPosition(e);
+        pointers.set(e.pointerId, position);
         svgElement.setPointerCapture?.(e.pointerId);
+
+        if (pointers.size === 2) {
+            // second finger down: commit any in-progress pan, start pinching
+            offsetX += displacementX;
+            offsetY += displacementY;
+            displacementX = 0;
+            displacementY = 0;
+            anchor = null;
+            pinched = true;
+        } else if (pointers.size === 1) {
+            anchor = position;
+            pinched = false;
+        } else {
+            anchor = null;
+        }
     }
 
     function handlePointerMove(e: PointerEvent) {
+        if (!pointers.has(e.pointerId)) return;
+
+        if (pointers.size === 2) {
+            const previousMidpoint = pointerMidpoint();
+            const previousDistance = pointerDistance();
+            pointers.set(e.pointerId, pointerPosition(e));
+
+            if (previousDistance > 0) {
+                zoomTo(clampScale(scale * (pointerDistance() / previousDistance)), previousMidpoint, pointerMidpoint());
+            }
+            return;
+        }
+
+        const position = pointerPosition(e);
+        pointers.set(e.pointerId, position);
+
         if (anchor) {
-            const position = pointerPosition(e);
             displacementX = anchor.x - position.x;
             displacementY = anchor.y - position.y;
         }
     }
 
     function handlePointerUp(e?: PointerEvent) {
-        // a pointer that barely moved is a tap on a cell, not a pan
-        const wasTap = e && anchor
+        if (e) {
+            pointers.delete(e.pointerId);
+        } else {
+            pointers.clear();
+        }
+
+        // a pointer that barely moved is a tap on a cell, not a pan or pinch
+        const wasTap = e && anchor && !pinched
             && Math.abs(displacementX) < 8
             && Math.abs(displacementY) < 8;
 
@@ -92,11 +157,24 @@
         }
     }
 
+    // Svelte registers template wheel handlers as passive, so attach directly
+    // to be able to preventDefault the page zoom/scroll
     $effect(() => {
-        let newMinX = Math.min(minX, Math.floor(offsetX / cellSize) - 5);
-        let newMinY = Math.min(minY, Math.floor(offsetY / cellSize) - 5);
-        let newMaxX = Math.max(maxX, Math.ceil((offsetX + width) / cellSize) + 5);
-        let newMaxY = Math.max(maxY, Math.ceil((offsetY + height) / cellSize) + 5);
+        const handleWheel = (e: WheelEvent) => {
+            if (disabled) return;
+            e.preventDefault();
+            zoomTo(clampScale(scale * Math.exp(-e.deltaY * 0.002)), pointerPosition(e));
+        };
+
+        svgElement.addEventListener("wheel", handleWheel, { passive: false });
+        return () => svgElement.removeEventListener("wheel", handleWheel);
+    })
+
+    $effect(() => {
+        let newMinX = Math.min(minX, Math.floor(offsetX / scale / cellSize) - 5);
+        let newMinY = Math.min(minY, Math.floor(offsetY / scale / cellSize) - 5);
+        let newMaxX = Math.max(maxX, Math.ceil((offsetX + width) / scale / cellSize) + 5);
+        let newMaxY = Math.max(maxY, Math.ceil((offsetY + height) / scale / cellSize) + 5);
 
         if (newMinX != minX) {
             requestCells(newMinX, newMinY, minX, newMaxY);
@@ -115,14 +193,21 @@
         }
     })
 
-    let visibleCells = $derived(cells.filter(cell => {
-        if (cell.x * cellSize + cellSize < offsetX + displacementX - 5 * cellSize) return false;
-        if (cell.y * cellSize + cellSize < offsetY + displacementY - 5 * cellSize) return false;
-        if (cell.x * cellSize > offsetX + displacementX + width + 5 * cellSize) return false;
-        if (cell.y * cellSize > offsetY + displacementY + height + 5 * cellSize) return false;
+    let visibleCells = $derived.by(() => {
+        const left = (offsetX + displacementX) / scale;
+        const top = (offsetY + displacementY) / scale;
+        const right = left + width / scale;
+        const bottom = top + height / scale;
 
-        return true;
-    }))
+        return cells.filter(cell => {
+            if (cell.x * cellSize + cellSize < left - 5 * cellSize) return false;
+            if (cell.y * cellSize + cellSize < top - 5 * cellSize) return false;
+            if (cell.x * cellSize > right + 5 * cellSize) return false;
+            if (cell.y * cellSize > bottom + 5 * cellSize) return false;
+
+            return true;
+        });
+    })
 
     const precision = 2;
 
@@ -173,7 +258,7 @@
 
 <svg
         bind:this={svgElement}
-        style="--cell-size: {cellSize*scale}px; --offset-x: {Math.round((-offsetX-displacementX-0.5)%cellSize*precision)/precision}px; --offset-y: {Math.round((-offsetY-displacementY-0.5)%cellSize*precision)/precision}px;{style}"
+        style="--cell-size: {cellSize*scale}px; --offset-x: {Math.round(((-offsetX-displacementX-0.5)%(cellSize*scale))*precision)/precision}px; --offset-y: {Math.round(((-offsetY-displacementY-0.5)%(cellSize*scale))*precision)/precision}px;{style}"
         viewBox={`${Math.round((offsetX+displacementX) / scale * precision) / precision} ${Math.round((offsetY+displacementY) / scale * precision) / precision} ${Math.round(width / scale * precision) / precision} ${Math.round(height / scale*precision)/precision}`}
         width={width}
         height={height}
@@ -183,19 +268,21 @@
         onpointercancel={() => handlePointerUp()}
         onpointerleave={() => handlePointerUp()}
 >
-    <rect
-            x={0}
-            y={0}
-            width={cellSize}
-            height={cellSize}
-            fill="rgba(255,255,255,0.75)"
-            stroke="rgba(0,0,0,0.125)"
-    />
-    <polygon
-            points={starPoints}
-            fill="rgba(0,255,0,0.25)"
-            stroke="rgba(0,0,0,0.25)"
-    />
+    {#if !cells.some(cell => cell.x === 0 && cell.y === 0 && cell.letter)}
+        <rect
+                x={0}
+                y={0}
+                width={cellSize}
+                height={cellSize}
+                fill="rgba(255,255,255,0.75)"
+                stroke="rgba(0,0,0,0.125)"
+        />
+        <polygon
+                points={starPoints}
+                fill="rgba(0,255,0,0.25)"
+                stroke="rgba(0,0,0,0.25)"
+        />
+    {/if}
     {#each visibleCells as cell (cell)}
         {#if cell.modifier}
             <Modifier

--- a/site/src/lib/Board.svelte
+++ b/site/src/lib/Board.svelte
@@ -308,7 +308,7 @@
                 stroke="rgba(0,0,0,0.25)"
         />
     {/if}
-    {#each visibleCells as cell (cell)}
+    {#each visibleCells as cell (`${cell.x},${cell.y}`)}
         {#if cell.modifier}
             <Modifier
                 cellSize={cellSize}

--- a/site/src/lib/Board.svelte
+++ b/site/src/lib/Board.svelte
@@ -8,6 +8,7 @@
         cells: Cell[];
         requestCells?: (x1: number, y1: number, x2: number, y2: number) => void;
         onCellTap?: (x: number, y: number) => void;
+        onViewChange?: (view: { minX: number; minY: number; maxX: number; maxY: number }) => void;
         ghostCells?: Cell[];
         highlightCell?: { x: number; y: number } | null;
         highlightCells?: { x: number; y: number }[];
@@ -26,6 +27,7 @@
         cells = [],
         requestCells = (x1, y1, x2, y2) => console.log(x1, y1, x2, y2),
         onCellTap,
+        onViewChange,
         ghostCells = [],
         highlightCell = null,
         highlightCells = [],
@@ -85,6 +87,17 @@
         offsetX = (cellX + 0.5) * cellSize * scale - width / 2;
         offsetY = (cellY + 0.5) * cellSize * scale - height / 2;
     }
+
+    // report the visible cell range so the page can tell when the player
+    // has wandered away from the action
+    $effect(() => {
+        onViewChange?.({
+            minX: (offsetX + displacementX) / scale / cellSize,
+            minY: (offsetY + displacementY) / scale / cellSize,
+            maxX: (offsetX + displacementX + width) / scale / cellSize,
+            maxY: (offsetY + displacementY + height) / scale / cellSize,
+        });
+    })
 
     // zoomTo changes the scale while keeping the board point under the given
     // screen position fixed (and optionally following it to a new position)

--- a/site/src/lib/Rack.svelte
+++ b/site/src/lib/Rack.svelte
@@ -3,12 +3,13 @@
 
     type Props = {
         letters: string[];
-        setLetters?: (letters: string[]) => void;
         letterPoints?: Record<string, number>;
         input?: string;
+        onTapLetter?: (letter: string, used: boolean) => void;
+        onReorder?: (letters: string[]) => void;
     }
 
-    const { letters, letterPoints={}, input="" }: Props = $props();
+    const { letters, letterPoints={}, input="", onTapLetter, onReorder }: Props = $props();
 
     let unusedLetters = $state<string[]>([]);
     let usedLetters = $state<string[]>([]);
@@ -28,6 +29,84 @@
         unusedLetters = nextUnusedLetters;
         usedLetters = nextUsedLetters;
     })
+
+    let listElement: HTMLUListElement;
+
+    // index within unusedLetters of the tile being dragged, if any
+    let dragIndex = $state<number | null>(null);
+    let dragMoved = false;
+    let dragStart = { x: 0, y: 0 };
+
+    // the tile slot closest to the pointer, robust to flex wrapping
+    function nearestDisplayIndex(e: PointerEvent) {
+        let best = 0;
+        let bestDistance = Infinity;
+
+        [...listElement.children].forEach((child, index) => {
+            const rect = child.getBoundingClientRect();
+            const distance = Math.hypot(
+                e.clientX - (rect.left + rect.width / 2),
+                e.clientY - (rect.top + rect.height / 2),
+            );
+            if (distance < bestDistance) {
+                bestDistance = distance;
+                best = index;
+            }
+        });
+
+        return best;
+    }
+
+    function handlePointerDown(e: PointerEvent, index: number) {
+        dragIndex = index;
+        dragMoved = false;
+        dragStart = { x: e.clientX, y: e.clientY };
+        try {
+            (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+        } catch {
+            // synthetic events have no active pointer to capture
+        }
+    }
+
+    function handlePointerMove(e: PointerEvent) {
+        if (dragIndex === null) return;
+
+        if (!dragMoved && Math.hypot(e.clientX - dragStart.x, e.clientY - dragStart.y) > 8) {
+            dragMoved = true;
+        }
+        if (!dragMoved) return;
+
+        const target = Math.max(0, Math.min(
+            unusedLetters.length - 1,
+            nearestDisplayIndex(e) - usedLetters.length,
+        ));
+
+        if (target !== dragIndex) {
+            const next = [...unusedLetters];
+            const [moved] = next.splice(dragIndex, 1);
+            next.splice(target, 0, moved);
+            unusedLetters = next;
+            dragIndex = target;
+        }
+    }
+
+    function handlePointerUp() {
+        if (dragIndex === null) return;
+
+        if (dragMoved) {
+            onReorder?.([...usedLetters, ...unusedLetters]);
+        } else {
+            onTapLetter?.(unusedLetters[dragIndex], false);
+        }
+
+        dragIndex = null;
+        dragMoved = false;
+    }
+
+    function handlePointerCancel() {
+        dragIndex = null;
+        dragMoved = false;
+    }
 </script>
 
 <style>
@@ -44,18 +123,31 @@
         display: block;
         padding: 0;
         margin: 0;
+        touch-action: none;
+        user-select: none;
+        -webkit-user-select: none;
+        cursor: pointer;
     }
 
+    li.dragging {
+        opacity: 0.5;
+    }
 </style>
 
-<ul>
-    {#each usedLetters as letter}
-        <li>
+<ul bind:this={listElement}>
+    {#each usedLetters as letter, index (index)}
+        <li onpointerup={() => onTapLetter?.(letter, true)}>
             <Tile cellSize={50} letter={letter} x={0} y={0} points={letterPoints[letter]} selected />
         </li>
     {/each}
-    {#each unusedLetters as letter}
-        <li>
+    {#each unusedLetters as letter, index (index)}
+        <li
+                class:dragging={dragIndex === index}
+                onpointerdown={(e) => handlePointerDown(e, index)}
+                onpointermove={handlePointerMove}
+                onpointerup={handlePointerUp}
+                onpointercancel={handlePointerCancel}
+        >
             <Tile cellSize={50} letter={letter} x={0} y={0} points={letterPoints[letter]} />
         </li>
     {/each}

--- a/site/src/lib/game.svelte.ts
+++ b/site/src/lib/game.svelte.ts
@@ -186,11 +186,26 @@ export  class GameController {
         this.board.cells = this.board.cells.concat(cells || []);
     }
 
+    #events: EventSource | null = null;
+
     streamUpdates() {
+        // the server decides at connection time whether we get our private
+        // events (like rack updates), so reconnect after identity changes
+        this.#events?.close();
+
         // server sent events
         let events = new EventSource(`${PUBLIC_API_URL}/api/v1/games/${this.id}/events`, {
             withCredentials: true
         });
+        this.#events = events;
+
+        // catch up on anything that happened while not connected - a reopen
+        // after joining, a dropped connection, or a server restart
+        events.onopen = async () => {
+            if (!this.loaded) return;
+            await this.refreshMeta();
+            await this.reloadBoard();
+        };
 
         events.addEventListener("GAME_STARTED", (e) => {
             this.started = true;
@@ -293,6 +308,7 @@ export  class GameController {
         }
 
         const data = await resp.json();
+        this.started = data.started;
         this.players = data.players || [];
         this.currentPlayerId = data.currentPlayerId;
         this.lettersRemaining = data.lettersRemaining;
@@ -300,6 +316,11 @@ export  class GameController {
         this.winnerIds = data.winnerIds || [];
         this.challenge = data.challenge || null;
         this.challengeableMoverId = data.challengeableMoverId || null;
+
+        // safety net in case a private rack event was missed
+        if (data.rack && [...data.rack].sort().join() !== [...this.rack].sort().join()) {
+            this.rack = data.rack;
+        }
     }
 
     mergeWord(placement: Placement) {
@@ -345,6 +366,10 @@ export  class GameController {
 
         this.playerId = playerId;
         this.players = players || [];
+
+        // the event stream was opened before we had an identity; reconnect so
+        // the server includes our private events
+        this.streamUpdates();
     }
 
     async start() {

--- a/site/src/lib/game.svelte.ts
+++ b/site/src/lib/game.svelte.ts
@@ -212,7 +212,11 @@ export  class GameController {
 
         let { cells } = await resp.json();
 
-        this.board.cells = this.board.cells.concat(cells || []);
+        // lazy-loaded ranges can overlap what's already loaded
+        const known = new Set(this.board.cells.map((cell: Cell) => `${cell.x},${cell.y}`));
+        const fresh = (cells || []).filter((cell: Cell) => !known.has(`${cell.x},${cell.y}`));
+
+        this.board.cells = this.board.cells.concat(fresh);
     }
 
     #events: EventSource | null = null;

--- a/site/src/lib/game.svelte.ts
+++ b/site/src/lib/game.svelte.ts
@@ -342,6 +342,23 @@ export  class GameController {
         this.board = { cells };
     }
 
+    // tapLetter adds an unused rack letter to the word being built, or
+    // removes a used one from it
+    tapLetter(letter: string, used: boolean) {
+        if (used) {
+            const index = this.input.lastIndexOf(letter);
+            if (index !== -1) {
+                this.input = this.input.slice(0, index) + this.input.slice(index + 1);
+            }
+        } else {
+            this.input += letter;
+        }
+    }
+
+    setRackOrder(letters: string[]) {
+        this.sortedRack = letters;
+    }
+
     async join(name: string) {
         let resp = await fetch(`${PUBLIC_API_URL}/api/v1/games/${this.id}`, {
             credentials: "include",

--- a/site/src/lib/game.svelte.ts
+++ b/site/src/lib/game.svelte.ts
@@ -35,6 +35,20 @@ export type Challenge = {
     eligibleVoters: number;
 }
 
+export type LastWord = {
+    playerId: string;
+    x: number;
+    y: number;
+    direction: "HORIZONTAL" | "VERTICAL";
+    word: string;
+}
+
+export type Announcement = {
+    text: string;
+    // board cell to jump to when the announcement is tapped
+    at?: { x: number; y: number };
+}
+
 export  class GameController {
     id = $state<string>("");
 
@@ -96,6 +110,21 @@ export  class GameController {
 
     // the id of the player who played the still-challengeable last word
     challengeableMoverId = $state<string | null>(null);
+
+    // the most recently played word, highlighted on the board until the next move
+    lastWord = $state<LastWord | null>(null);
+
+    announcement = $state<Announcement | null>(null);
+
+    #announcementTimer: ReturnType<typeof setTimeout> | undefined;
+
+    announce(text: string, at?: { x: number; y: number }) {
+        this.announcement = { text, at };
+        clearTimeout(this.#announcementTimer);
+        this.#announcementTimer = setTimeout(() => {
+            this.announcement = null;
+        }, 8000);
+    }
 
     myVote = $state<boolean>(false);
 
@@ -234,6 +263,25 @@ export  class GameController {
             this.challengeableMoverId = played.playerId;
             this.myVote = false;
 
+            this.lastWord = {
+                playerId: played.playerId,
+                x: played.x,
+                y: played.y,
+                direction: played.direction,
+                word: played.word,
+            };
+
+            if (played.playerId !== this.playerId) {
+                const middle = Math.floor(played.word.length / 2);
+                this.announce(
+                    `${this.playerName(played.playerId)} played ${played.word} for ${played.points} point${played.points === 1 ? "" : "s"}`,
+                    {
+                        x: played.direction === "HORIZONTAL" ? played.x + middle : played.x,
+                        y: played.direction === "VERTICAL" ? played.y + middle : played.y,
+                    },
+                );
+            }
+
             const player = this.getPlayerById(played.playerId);
             if (player) {
                 player.score += played.points;
@@ -248,16 +296,24 @@ export  class GameController {
         })
 
         events.addEventListener("TURN_PASSED", (e) => {
-            const { nextPlayerId } = JSON.parse(e.data);
+            const { playerId, nextPlayerId } = JSON.parse(e.data);
             this.currentPlayerId = nextPlayerId;
             this.challengeableMoverId = null;
+            this.lastWord = null;
+            if (playerId !== this.playerId) {
+                this.announce(`${this.playerName(playerId)} skipped their turn`);
+            }
             this.refreshMeta();
         })
 
         events.addEventListener("LETTERS_EXCHANGED", (e) => {
-            const { nextPlayerId } = JSON.parse(e.data);
+            const { playerId, count, nextPlayerId } = JSON.parse(e.data);
             this.currentPlayerId = nextPlayerId;
             this.challengeableMoverId = null;
+            this.lastWord = null;
+            if (playerId !== this.playerId) {
+                this.announce(`${this.playerName(playerId)} swapped ${count} letter${count === 1 ? "" : "s"}`);
+            }
             this.refreshMeta();
         })
 
@@ -273,14 +329,18 @@ export  class GameController {
         })
 
         events.addEventListener("CHALLENGE_RESOLVED", async (e) => {
-            const { upheld } = JSON.parse(e.data);
+            const { upheld, rescindedWord } = JSON.parse(e.data);
             this.challenge = null;
             this.challengeableMoverId = null;
+            this.lastWord = null;
             this.myVote = false;
 
             if (upheld) {
+                this.announce(`${rescindedWord ? `"${rescindedWord}"` : "The word"} was voted invalid and removed`);
                 // the word came off the board; scores changed too
                 await this.reloadBoard();
+            } else {
+                this.announce("The challenge failed - the word stands");
             }
             await this.refreshMeta();
         })

--- a/site/src/routes/play/+page.svelte
+++ b/site/src/routes/play/+page.svelte
@@ -112,6 +112,27 @@
         && game.challengeableMoverId !== game.playerId
     );
 
+    let boardComponent = $state<ReturnType<typeof Board> | undefined>();
+
+    // cells of the most recently played word, tinted on the board
+    let lastWordCells = $derived.by(() => {
+        const lastWord = game.lastWord;
+        if (!lastWord) return [];
+
+        return [...lastWord.word].map((_, i) => ({
+            x: lastWord.direction === "HORIZONTAL" ? lastWord.x + i : lastWord.x,
+            y: lastWord.direction === "VERTICAL" ? lastWord.y + i : lastWord.y,
+        }));
+    });
+
+    function handleAnnouncementTap() {
+        const at = game.announcement?.at;
+        if (at) {
+            boardComponent?.centerOn(at.x, at.y);
+        }
+        game.announcement = null;
+    }
+
     let canVote = $derived(
         game.challenge !== null
         && !game.myVote
@@ -189,6 +210,17 @@
         margin: 0;
         font-size: 0.85rem;
         color: rgba(0,0,0,0.6);
+    }
+
+    .announcement {
+        font: inherit;
+        font-size: 0.85rem;
+        padding: 0.35rem 0.9rem;
+        border-radius: 999px;
+        border: 1px solid rgba(37,99,235,0.4);
+        background-color: rgba(37,99,235,0.12);
+        color: #1e40af;
+        cursor: pointer;
     }
 
     .actions {
@@ -276,11 +308,13 @@
     <p>Loading game...</p>
 {:else}
     <Board
+            bind:this={boardComponent}
             cells={[...game.board.cells]}
             requestCells={(x1, y1, x2, y2) => game.loadBoard(x1, y1, x2, y2)}
             onCellTap={handleCellTap}
             ghostCells={ghostCells}
             highlightCell={selectedCell}
+            highlightCells={lastWordCells}
             width={boardWidth}
             height={boardHeight}
             offsetX={offsetX}
@@ -304,6 +338,11 @@
                     {game.myTurn ? "Your turn" : `${game.playerName(game.currentPlayerId)}'s turn`}
                     · {game.lettersRemaining} letters left
                 </p>
+            {/if}
+            {#if game.announcement}
+                <button class="announcement" onclick={handleAnnouncementTap}>
+                    {game.announcement.text}{game.announcement.at ? " · tap to view" : ""}
+                </button>
             {/if}
         </header>
     {/if}

--- a/site/src/routes/play/+page.svelte
+++ b/site/src/routes/play/+page.svelte
@@ -114,6 +114,14 @@
 
     let boardComponent = $state<ReturnType<typeof Board> | undefined>();
 
+    let boardView = $state<{ minX: number; minY: number; maxX: number; maxY: number } | null>(null);
+
+    // offer a way home when the center star has drifted off-screen
+    let showRecenter = $derived(
+        boardView !== null
+        && (boardView.maxX < 0 || boardView.minX > 1 || boardView.maxY < 0 || boardView.minY > 1)
+    );
+
     // cells of the most recently played word, tinted on the board
     let lastWordCells = $derived.by(() => {
         const lastWord = game.lastWord;
@@ -223,6 +231,20 @@
         cursor: pointer;
     }
 
+    .recenter {
+        position: fixed;
+        right: 1rem;
+        bottom: 40%;
+        font: inherit;
+        font-size: 0.85rem;
+        padding: 0.5rem 1rem;
+        border-radius: 999px;
+        border: 1px solid rgba(0,0,0,0.2);
+        background-color: rgba(255,255,255,0.9);
+        box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+        cursor: pointer;
+    }
+
     .actions {
         display: flex;
         flex-wrap: wrap;
@@ -312,6 +334,7 @@
             cells={[...game.board.cells]}
             requestCells={(x1, y1, x2, y2) => game.loadBoard(x1, y1, x2, y2)}
             onCellTap={handleCellTap}
+            onViewChange={(view) => boardView = view}
             ghostCells={ghostCells}
             highlightCell={selectedCell}
             highlightCells={lastWordCells}
@@ -323,6 +346,12 @@
             style="position: fixed; top: 0; left: 0; width: 100%; height: 100%;"
             cellSize={50}
     />
+
+    {#if showRecenter}
+        <button class="recenter" onclick={() => boardComponent?.centerOn(0, 0)}>
+            Back to center
+        </button>
+    {/if}
 
     {#if game.started}
         <header class="panel">

--- a/site/src/routes/play/+page.svelte
+++ b/site/src/routes/play/+page.svelte
@@ -365,7 +365,13 @@
             </div>
         {:else}
             <div style="width: 100%; max-width: 24rem;">
-                <Rack letters={game.sortedRack} letterPoints={game.letterPoints} input={game.input} />
+                <Rack
+                        letters={game.sortedRack}
+                        letterPoints={game.letterPoints}
+                        input={game.input}
+                        onTapLetter={(letter, used) => game.tapLetter(letter, used)}
+                        onReorder={(letters) => game.setRackOrder(letters)}
+                />
                 {#if !game.finished}
                     <input type="text" bind:value={game.input} placeholder="WORD" class="input" />
                     <p class="hint">

--- a/site/src/routes/play/+page.svelte
+++ b/site/src/routes/play/+page.svelte
@@ -366,10 +366,12 @@
         {:else}
             <div style="width: 100%; max-width: 24rem;">
                 <Rack letters={game.sortedRack} letterPoints={game.letterPoints} input={game.input} />
-                {#if game.myTurn}
+                {#if !game.finished}
                     <input type="text" bind:value={game.input} placeholder="WORD" class="input" />
                     <p class="hint">
-                        {#if game.board.cells.some(cell => cell.letter)}
+                        {#if !game.myTurn}
+                            Plan your next word while you wait.
+                        {:else if game.board.cells.some(cell => cell.letter)}
                             Type a word, then tap the square where it starts.
                         {:else}
                             Type a word, then tap the center star to place it.
@@ -379,14 +381,14 @@
             </div>
             <div class="actions">
                 {#if game.myTurn}
-                    <button onclick={() => game.pass()}>Pass</button>
+                    <button onclick={() => game.pass()}>Skip my turn</button>
                     <button
                             disabled={game.input.length === 0}
                             onclick={() => game.exchange([...game.input])}
-                    >Exchange{game.input.length > 0 ? ` ${game.input.length}` : ""}</button>
+                    >{game.input.length > 0 ? `Swap ${game.input.length} letters` : "Swap letters"}</button>
                 {/if}
-                {#if canChallenge}
-                    <button onclick={() => game.challengeWord()}>Challenge last word</button>
+                {#if canChallenge && game.challengeableMoverId}
+                    <button onclick={() => game.challengeWord()}>Challenge {game.playerName(game.challengeableMoverId)}'s word</button>
                 {/if}
             </div>
         {/if}


### PR DESCRIPTION
## Summary

Everything from the playtest with Gracie, plus move visibility and persistence groundwork:

## Racks not appearing until reload

The SSE handler reads the player cookie **once, when the stream opens** — but the page opens the stream before the player joins, so a player who joins after page load never gets their private channel (rack updates, their letters on game start). Three-part fix:

- The client reconnects the event stream after a successful join
- The server flushes SSE headers immediately so the browser's `open` event fires right away (`internal/api/events.go`)
- On every stream (re)connect, the client re-syncs game state and board — closing the reconnect race and healing missed events after network drops or server restarts/deploys

## Zoom (verified with real touch input)

Pinch-to-zoom (two-pointer) and mouse-wheel zoom, both zooming around the pointer/pinch midpoint, clamped to 0.35×–2.5×. The board's scale handling had latent bugs that never mattered at the fixed 1× — lazy cell fetching, visibility culling, and the CSS background grid all ignored `scale` — fixed alongside. Verified via CDP two-finger touch events (not synthetic DOM events, which Svelte's delegated handlers ignore): pinch zooms to the clamp, and a tap **while pinch-zoomed** still resolves to the correct cell.

## Interactive rack

- **Tap an unused tile** to append it to the word; **tap a used tile** to remove it — typing still works
- **Drag tiles to reorder** the rack (tap-vs-drag distinguished by an 8px movement threshold, works with touch)

## Move visibility

- The most recently played word stays **tinted on the board** until the next move — which doubles as marking exactly what a challenge would target
- A tappable **banner announces moves** ("Gracie played TANGO for 24 points"); tapping it centers the board on the word. Passes, swaps, and challenge outcomes are announced the same way

## Clearer controls

- "Pass" → "**Skip my turn**", "Exchange" → "**Swap letters**", challenge button names the player ("Challenge Alice's word")
- Word input stays visible on other players' turns for planning
- The center star no longer shows through the first placed letter
- Tapping out of turn says whose turn it is

## Persistence and cleanup

- `fly.toml` mounts a volume at `/data` and sets `DATA_DIR` so games survive machine auto-stops and deploys. **Prerequisite before merging:** `fly volumes create words_data --region den --size 1`
- The server sweeps hourly: unfinished games idle for 14 days are deleted; **finished games are kept** so they can be displayed in the app later (`FS.RemoveIdleGames`, covered by table-driven tests)

## Testing

- `go vet` / `go test ./...` green (including new store cleanup tests); site builds clean, no new check errors
- Scripted two-browser session against the real server, three consecutive passes: both players see racks live without reloading (including blank tiles), wheel + pinch zoom work, zoomed taps land correctly, drag-reorder works, a word built by tapping tiles plays end to end, the other player sees the announcement banner and highlighted word, and tapping the banner jumps the board to the word