### PR TITLE
Drag ghost, observer mode, * placeholders, iOS pinch, off-turn planning

### DIFF
--- a/internal/words/board.go
+++ b/internal/words/board.go
@@ -38,6 +38,38 @@ func (board *Board) Letter(point Point) (rune, bool) {
 	return letter, exists
 }
 
+// PlaceholderLetter marks a position in a typed word that must be filled by
+// a letter already on the board.
+const PlaceholderLetter = '*'
+
+// FillPlaceholders replaces each placeholder in the word with the board
+// letter at its position, reporting false when one lands on an empty cell.
+func (board *Board) FillPlaceholders(word Word) (Word, bool) {
+	letters := word.Letters()
+
+	changed := false
+	for position, letter := range letters {
+		if letter != PlaceholderLetter {
+			continue
+		}
+
+		point, _, _ := word.Index(position)
+		existing, occupied := board.Letter(point)
+		if !occupied {
+			return Word{}, false
+		}
+
+		letters[position] = existing
+		changed = true
+	}
+
+	if !changed {
+		return word, true
+	}
+
+	return NewWord(word.Start(), word.Direction(), string(letters)), true
+}
+
 // Modifier returns the modifier at the given point and whether one exists there.
 func (board *Board) Modifier(point Point) (Modifier, bool) {
 	return board.config.Modifiers.Get(point.Column(), point.Row())

--- a/internal/words/game.go
+++ b/internal/words/game.go
@@ -448,6 +448,11 @@ func (game *Game) FindPlacements(playerID string, point Point, letters string) (
 			deltaColumn, deltaRow := direction.Vector(-offset)
 			word := NewWord(point.Offset(deltaColumn, deltaRow), direction, letters)
 
+			word, resolvable := game.board.FillPlaceholders(word)
+			if !resolvable {
+				continue
+			}
+
 			result, err := game.checkWord(playerID, word)
 			if err != nil {
 				continue

--- a/internal/words/game_test.go
+++ b/internal/words/game_test.go
@@ -280,6 +280,7 @@ func TestGame_FindPlacements(t *testing.T) {
 	tests := []struct {
 		name           string
 		skipStart      bool
+		setup          bool
 		letters        string
 		wantErr        error
 		wantPlacements int
@@ -287,6 +288,9 @@ func TestGame_FindPlacements(t *testing.T) {
 		{name: "rejects an unstarted game", skipStart: true, letters: "AA", wantErr: words.ErrGameNotStarted},
 		{name: "rejects letters with no placement", letters: "ZZ", wantErr: words.ErrCannotPlayWord},
 		{name: "finds placements through the point", letters: "AA", wantPlacements: 4},
+		{name: "fills placeholders from board letters", setup: true, letters: "*A", wantPlacements: 1},
+		{name: "rejects placeholders over empty cells", letters: "*A", wantErr: words.ErrCannotPlayWord},
+		{name: "rejects a word of only placeholders", setup: true, letters: "*", wantErr: words.ErrCannotPlayWord},
 	}
 
 	for _, test := range tests {
@@ -296,6 +300,10 @@ func TestGame_FindPlacements(t *testing.T) {
 			game := newLobbyGame(t, 1, testConfig(map[rune]int{'A': 20}, 3))
 			if !test.skipStart {
 				require.NoError(t, game.Start())
+			}
+			if test.setup {
+				_, err := game.PlayWord(game.Players()[0].ID(), horizontal(0, 0, "AA"))
+				require.NoError(t, err)
 			}
 
 			placements, err := game.FindPlacements(game.Players()[0].ID(), words.NewPoint(0, 0), test.letters)

--- a/site/src/lib/Board.svelte
+++ b/site/src/lib/Board.svelte
@@ -182,8 +182,8 @@
         }
     }
 
-    // Svelte registers template wheel handlers as passive, so attach directly
-    // to be able to preventDefault the page zoom/scroll
+    // Svelte registers template wheel/touch handlers as passive, so attach
+    // directly to be able to preventDefault the page zoom/scroll
     $effect(() => {
         const handleWheel = (e: WheelEvent) => {
             if (disabled) return;
@@ -191,8 +191,27 @@
             zoomTo(clampScale(scale * Math.exp(-e.deltaY * 0.002)), pointerPosition(e));
         };
 
+        // iOS Safari ignores touch-action for its page pinch-zoom and
+        // tab-switcher gestures; consume multi-touch and gesture events so a
+        // pinch over the board only zooms the board
+        const consumeMultiTouch = (e: TouchEvent) => {
+            if (e.touches.length > 1) e.preventDefault();
+        };
+        const consumeGesture = (e: Event) => e.preventDefault();
+
         svgElement.addEventListener("wheel", handleWheel, { passive: false });
-        return () => svgElement.removeEventListener("wheel", handleWheel);
+        svgElement.addEventListener("touchstart", consumeMultiTouch, { passive: false });
+        svgElement.addEventListener("touchmove", consumeMultiTouch, { passive: false });
+        svgElement.addEventListener("gesturestart", consumeGesture);
+        svgElement.addEventListener("gesturechange", consumeGesture);
+
+        return () => {
+            svgElement.removeEventListener("wheel", handleWheel);
+            svgElement.removeEventListener("touchstart", consumeMultiTouch);
+            svgElement.removeEventListener("touchmove", consumeMultiTouch);
+            svgElement.removeEventListener("gesturestart", consumeGesture);
+            svgElement.removeEventListener("gesturechange", consumeGesture);
+        };
     })
 
     $effect(() => {

--- a/site/src/lib/Board.svelte
+++ b/site/src/lib/Board.svelte
@@ -82,10 +82,48 @@
         return Math.min(maxScale, Math.max(minScale, value));
     }
 
-    // centerOn pans the view so the given cell sits at the center of the board
+    // centerOn glides the view so the given cell sits at the center of the
+    // board, easing in and out
     export function centerOn(cellX: number, cellY: number) {
-        offsetX = (cellX + 0.5) * cellSize * scale - width / 2;
-        offsetY = (cellY + 0.5) * cellSize * scale - height / 2;
+        glideTo(
+            (cellX + 0.5) * cellSize * scale - width / 2,
+            (cellY + 0.5) * cellSize * scale - height / 2,
+        );
+    }
+
+    let glideFrame = 0;
+
+    function glideTo(targetX: number, targetY: number) {
+        cancelAnimationFrame(glideFrame);
+
+        const fromX = offsetX;
+        const fromY = offsetY;
+        const distance = Math.hypot(targetX - fromX, targetY - fromY);
+
+        if (distance < 1 || window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+            offsetX = targetX;
+            offsetY = targetY;
+            return;
+        }
+
+        // farther glides get a little longer, capped to stay snappy
+        const duration = Math.min(900, 350 + distance * 0.15);
+        const easeInOut = (t: number) => t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+        let started: number | null = null;
+        const step = (now: number) => {
+            if (started === null) started = now;
+            const eased = easeInOut(Math.min(1, (now - started) / duration));
+
+            offsetX = fromX + (targetX - fromX) * eased;
+            offsetY = fromY + (targetY - fromY) * eased;
+
+            if (eased < 1) {
+                glideFrame = requestAnimationFrame(step);
+            }
+        };
+
+        glideFrame = requestAnimationFrame(step);
     }
 
     // report the visible cell range so the page can tell when the player
@@ -109,6 +147,7 @@
 
     function handlePointerDown(e: PointerEvent) {
         if (disabled) return;
+        cancelAnimationFrame(glideFrame);
         const position = pointerPosition(e);
         pointers.set(e.pointerId, position);
         try {
@@ -188,6 +227,7 @@
         const handleWheel = (e: WheelEvent) => {
             if (disabled) return;
             e.preventDefault();
+            cancelAnimationFrame(glideFrame);
             zoomTo(clampScale(scale * Math.exp(-e.deltaY * 0.002)), pointerPosition(e));
         };
 

--- a/site/src/lib/Rack.svelte
+++ b/site/src/lib/Rack.svelte
@@ -34,8 +34,13 @@
 
     // index within unusedLetters of the tile being dragged, if any
     let dragIndex = $state<number | null>(null);
-    let dragMoved = false;
+    let dragMoved = $state(false);
     let dragStart = { x: 0, y: 0 };
+
+    // where the dragged tile floats; lifted above the finger on touch so it
+    // isn't hidden under it
+    let dragPosition = $state({ x: 0, y: 0 });
+    let dragLift = $state(0);
 
     // the tile slot closest to the pointer, robust to flex wrapping
     function nearestDisplayIndex(e: PointerEvent) {
@@ -61,6 +66,8 @@
         dragIndex = index;
         dragMoved = false;
         dragStart = { x: e.clientX, y: e.clientY };
+        dragPosition = { x: e.clientX, y: e.clientY };
+        dragLift = e.pointerType === "touch" ? 65 : 25;
         try {
             (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
         } catch {
@@ -70,6 +77,8 @@
 
     function handlePointerMove(e: PointerEvent) {
         if (dragIndex === null) return;
+
+        dragPosition = { x: e.clientX, y: e.clientY };
 
         if (!dragMoved && Math.hypot(e.clientX - dragStart.x, e.clientY - dragStart.y) > 8) {
             dragMoved = true;
@@ -130,7 +139,15 @@
     }
 
     li.dragging {
-        opacity: 0.5;
+        opacity: 0.25;
+    }
+
+    .floating {
+        position: fixed;
+        z-index: 100;
+        pointer-events: none;
+        transform: scale(1.2);
+        filter: drop-shadow(0 6px 10px rgba(0,0,0,0.3));
     }
 </style>
 
@@ -152,3 +169,9 @@
         </li>
     {/each}
 </ul>
+
+{#if dragIndex !== null && dragMoved}
+    <div class="floating" style="left: {dragPosition.x - 25}px; top: {dragPosition.y - dragLift}px;">
+        <Tile cellSize={50} letter={unusedLetters[dragIndex]} x={0} y={0} points={letterPoints[unusedLetters[dragIndex]]} selected />
+    </div>
+{/if}

--- a/site/src/lib/game.svelte.ts
+++ b/site/src/lib/game.svelte.ts
@@ -267,6 +267,11 @@ export  class GameController {
             this.challengeableMoverId = played.playerId;
             this.myVote = false;
 
+            // the board changed under any placement someone was previewing
+            if (played.playerId !== this.playerId) {
+                this.clearPlacements();
+            }
+
             this.lastWord = {
                 playerId: played.playerId,
                 x: played.x,

--- a/site/src/lib/game.svelte.ts
+++ b/site/src/lib/game.svelte.ts
@@ -439,8 +439,8 @@ export  class GameController {
         });
 
         if (!resp.ok) {
-            console.error("failed to join game", await resp.json());
-            throw new Error(`Failed to join game ${this.id}`);
+            this.error = await this.errorMessage(resp, "Couldn't join the game.");
+            return;
         }
 
         let { playerId, players } = await resp.json();

--- a/site/src/routes/play/+page.svelte
+++ b/site/src/routes/play/+page.svelte
@@ -41,7 +41,8 @@
     let name = $state("");
 
     $effect(() => {
-        game.input = game.input.toUpperCase().replace(/[^A-Z]/g, "");
+        // * is a placeholder for a letter already on the board
+        game.input = game.input.toUpperCase().replace(/[^A-Z*]/g, "");
     })
 
     let selectedCell = $state<{ x: number; y: number } | null>(null);
@@ -229,6 +230,10 @@
         background-color: rgba(37,99,235,0.12);
         color: #1e40af;
         cursor: pointer;
+    }
+
+    .input-tools {
+        margin-top: 0.5rem;
     }
 
     .recenter {
@@ -446,11 +451,15 @@
                 />
                 {#if !game.finished}
                     <input type="text" bind:value={game.input} placeholder="WORD" class="input" />
+                    <div class="actions input-tools">
+                        <button onclick={() => game.input += "*"} title="a letter already on the board">＋ board letter</button>
+                        <button disabled={!game.input} onclick={() => game.input = game.input.slice(0, -1)}>⌫ delete</button>
+                    </div>
                     <p class="hint">
                         {#if !game.myTurn}
                             Plan your next word while you wait.
                         {:else if game.board.cells.some(cell => cell.letter)}
-                            Type a word, then tap the square where it starts.
+                            Tap where the word starts. "＋ board letter" adds a * for a letter you're crossing.
                         {:else}
                             Type a word, then tap the center star to place it.
                         {/if}

--- a/site/src/routes/play/+page.svelte
+++ b/site/src/routes/play/+page.svelte
@@ -48,12 +48,8 @@
     let selectedCell = $state<{ x: number; y: number } | null>(null);
 
     async function handleCellTap(x: number, y: number) {
-        if (!game.started || game.finished || game.challenge) {
-            return;
-        }
-
-        if (!game.myTurn) {
-            game.error = `It's ${game.playerName(game.currentPlayerId)}'s turn.`;
+        // planning is allowed off-turn; playing isn't. Observers can't plan.
+        if (!game.started || game.finished || game.challenge || !game.playerId) {
             return;
         }
 
@@ -132,6 +128,13 @@
             x: lastWord.direction === "HORIZONTAL" ? lastWord.x + i : lastWord.x,
             y: lastWord.direction === "VERTICAL" ? lastWord.y + i : lastWord.y,
         }));
+    });
+
+    // a placement preview only makes sense while placements are offered
+    $effect(() => {
+        if (game.placements.length === 0) {
+            selectedCell = null;
+        }
     });
 
     function handleAnnouncementTap() {
@@ -429,7 +432,7 @@
                 {#if game.placements.length > 1}
                     <button onclick={() => game.selectedPlacement = (game.selectedPlacement + game.placements.length - 1) % game.placements.length}>&larr;</button>
                 {/if}
-                <button class="primary" onclick={playWord}>
+                <button class="primary" disabled={!game.myTurn} onclick={playWord}>
                     Play {selectedPlacement.word} for {selectedPlacement.points} pts
                     {#if game.placements.length > 1}
                         ({game.selectedPlacement + 1}/{game.placements.length})
@@ -440,6 +443,9 @@
                 {/if}
                 <button onclick={cancelPlacement}>Cancel</button>
             </div>
+            {#if !game.myTurn}
+                <p class="hint">Ready to go - you can play it when your turn comes.</p>
+            {/if}
         {:else}
             <div style="width: 100%; max-width: 24rem;">
                 <Rack
@@ -457,7 +463,7 @@
                     </div>
                     <p class="hint">
                         {#if !game.myTurn}
-                            Plan your next word while you wait.
+                            Plan while you wait: build a word and tap the board to preview it.
                         {:else if game.board.cells.some(cell => cell.letter)}
                             Tap where the word starts. "＋ board letter" adds a * for a letter you're crossing.
                         {:else}

--- a/site/src/routes/play/+page.svelte
+++ b/site/src/routes/play/+page.svelte
@@ -382,14 +382,18 @@
         {/if}
 
         {#if !game.playerId}
-            <div>
-                <label>
-                    Name
-                    <input type="text" bind:value={name}>
-                </label>
+            {#if game.started}
+                <p class="hint">You're watching this game - it already started, so you can't join.</p>
+            {:else}
+                <div>
+                    <label>
+                        Name
+                        <input type="text" bind:value={name}>
+                    </label>
 
-                <button class="button" onclick={async () => await game.join(name)}>Join game</button>
-            </div>
+                    <button class="button" onclick={async () => await game.join(name)}>Join game</button>
+                </div>
+            {/if}
         {:else if !game.started}
             <div class="actions">
                 <button class="primary" onclick={(e) => {


### PR DESCRIPTION
## Summary

Playtest follow-ups, round two:

## Floating drag tile

Dragging a rack tile was disorienting — your finger covered the tile. The dragged letter now renders as a floating copy that follows the pointer, lifted **above** the finger on touch, scaled up with a drop shadow. The vacated slot dims so it's clear where the tile will land.

## Observer mode

Visitors opening a game that already started saw a join form that could only fail (the backend rejects late joins). They now get a **spectator view**: live board, scores, move announcements, and a "You're watching this game" note. Pre-start join failures surface as a friendly inline message instead of throwing.

## `*` placeholders for crossing words

The word input accepts `*` meaning "the letter already on the board here" — type or tap-build `FA*L`, tap the anchor square, and `Game.FindPlacements` resolves each `*` against the board per candidate alignment (`Board.FillPlaceholders`), skipping alignments where one lands on an empty cell. Offered placements come back fully resolved. Two buttons under the input — **＋ board letter** and **⌫ delete** — make play fully keyboard-free on iOS.

## Pinch zoom on iOS Safari

`touch-action: none` doesn't stop iOS Safari's page pinch-zoom or the pinch-to-tab-switcher gesture, so pinching over the board zoomed the page. The board now consumes multi-touch `touchstart`/`touchmove` and `gesturestart`/`gesturechange` directly (non-passive listeners — Svelte template touch handlers are passive), so a pinch over the board only zooms the board.

## Planning while it's not your turn

Everything except actually playing now works off-turn: build a word (type, tap tiles, `*`, backspace), tap the board, browse ghost previews and placement options — the **Play button alone waits for your turn**, with a "you can play it when your turn comes" hint. Stale previews are cleared automatically when another player's word lands, since the board they were computed against changed.

## Testing

- `go vet` / `go test ./...` green; table cases cover placeholder resolution, placeholders over empty cells, all-placeholder words
- Scripted browser session, full pass: observer view; floating tile visible mid-drag (CDP touch); multi-touch over the board asserted `defaultPrevented` (the mechanism that stops iOS page pinch); crossing word built keyboard-free resolves `*` in the offered placement; backspace works; off-turn player previews a placement with Play disabled; all prior regression checks pass