### PR TITLE
Redesign the word input row and fix the invisible drag tile

### DIFF
--- a/site/src/lib/Rack.svelte
+++ b/site/src/lib/Rack.svelte
@@ -116,6 +116,18 @@
         dragIndex = null;
         dragMoved = false;
     }
+
+    // ancestors with backdrop-filter (the footer panel) become the containing
+    // block for position:fixed, throwing off viewport coordinates - render
+    // the floating tile from the body instead
+    function portal(node: HTMLElement) {
+        document.body.appendChild(node);
+        return {
+            destroy() {
+                node.remove();
+            },
+        };
+    }
 </script>
 
 <style>
@@ -171,7 +183,7 @@
 </ul>
 
 {#if dragIndex !== null && dragMoved}
-    <div class="floating" style="left: {dragPosition.x - 25}px; top: {dragPosition.y - dragLift}px;">
+    <div class="floating" use:portal style="left: {dragPosition.x - 25}px; top: {dragPosition.y - dragLift}px;">
         <Tile cellSize={50} letter={unusedLetters[dragIndex]} x={0} y={0} points={letterPoints[unusedLetters[dragIndex]]} selected />
     </div>
 {/if}

--- a/site/src/routes/play/+page.svelte
+++ b/site/src/routes/play/+page.svelte
@@ -261,31 +261,41 @@
 
     .actions button {
         font: inherit;
-        padding: 0.5rem 0.9rem;
+        padding: 0 0.9rem;
+        height: 50px;
         border-radius: 0.5rem;
         border: 1px solid rgba(0,0,0,0.25);
         background-color: rgba(255,255,255,0.85);
         cursor: pointer;
     }
 
+    /* the input row matches the 50px rack tiles: same height, same 20px letters */
     .input-row {
         display: flex;
         align-items: stretch;
         gap: 0.5rem;
         margin-top: 0.5rem;
         margin-bottom: 0.5rem;
+        height: 50px;
     }
 
     .input-row .input {
         flex: 1;
         margin: 0;
         min-width: 0;
+        padding: 0 0.75rem;
+        font-size: 1.25rem;
+        letter-spacing: 0.1em;
     }
 
     .tool {
         font: inherit;
-        width: 3rem;
+        font-size: 1.5rem;
+        width: 50px;
         flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         border-radius: 0.5rem;
         border: 1px solid rgba(0, 0, 0, 0.25);
         background-color: rgba(255, 255, 255, 0.75);
@@ -484,7 +494,7 @@
                 />
                 {#if !game.finished}
                     <div class="input-row">
-                        <button class="tool" title="a letter already on the board" aria-label="board letter" onclick={() => game.input += "*"}>★</button>
+                        <button class="tool" title="a letter already on the board" aria-label="board letter" onclick={() => game.input += "*"}>*</button>
                         <input type="text" bind:value={game.input} placeholder="WORD" class="input" />
                         <button class="tool" disabled={!game.input} aria-label="delete last letter" onclick={() => game.input = game.input.slice(0, -1)}>⌫</button>
                     </div>

--- a/site/src/routes/play/+page.svelte
+++ b/site/src/routes/play/+page.svelte
@@ -145,6 +145,9 @@
         game.announcement = null;
     }
 
+    // letters eligible for swapping - placeholders aren't rack letters
+    let swapLetters = $derived([...game.input].filter(letter => letter !== "*"));
+
     let canVote = $derived(
         game.challenge !== null
         && !game.myVote
@@ -235,10 +238,6 @@
         cursor: pointer;
     }
 
-    .input-tools {
-        margin-top: 0.5rem;
-    }
-
     .recenter {
         position: fixed;
         right: 1rem;
@@ -262,12 +261,40 @@
 
     .actions button {
         font: inherit;
-        font-size: 0.9rem;
-        padding: 0.4rem 0.9rem;
+        padding: 0.5rem 0.9rem;
         border-radius: 0.5rem;
         border: 1px solid rgba(0,0,0,0.25);
         background-color: rgba(255,255,255,0.85);
         cursor: pointer;
+    }
+
+    .input-row {
+        display: flex;
+        align-items: stretch;
+        gap: 0.5rem;
+        margin-top: 0.5rem;
+        margin-bottom: 0.5rem;
+    }
+
+    .input-row .input {
+        flex: 1;
+        margin: 0;
+        min-width: 0;
+    }
+
+    .tool {
+        font: inherit;
+        width: 3rem;
+        flex-shrink: 0;
+        border-radius: 0.5rem;
+        border: 1px solid rgba(0, 0, 0, 0.25);
+        background-color: rgba(255, 255, 255, 0.75);
+        cursor: pointer;
+    }
+
+    .tool:disabled {
+        opacity: 0.5;
+        cursor: default;
     }
 
     .actions button.primary {
@@ -456,32 +483,21 @@
                         onReorder={(letters) => game.setRackOrder(letters)}
                 />
                 {#if !game.finished}
-                    <input type="text" bind:value={game.input} placeholder="WORD" class="input" />
-                    <div class="actions input-tools">
-                        <button onclick={() => game.input += "*"} title="a letter already on the board">＋ board letter</button>
-                        <button disabled={!game.input} onclick={() => game.input = game.input.slice(0, -1)}>⌫ delete</button>
+                    <div class="input-row">
+                        <button class="tool" title="a letter already on the board" aria-label="board letter" onclick={() => game.input += "*"}>★</button>
+                        <input type="text" bind:value={game.input} placeholder="WORD" class="input" />
+                        <button class="tool" disabled={!game.input} aria-label="delete last letter" onclick={() => game.input = game.input.slice(0, -1)}>⌫</button>
                     </div>
-                    <p class="hint">
-                        {#if !game.myTurn}
-                            Plan while you wait: build a word and tap the board to preview it.
-                        {:else if game.board.cells.some(cell => cell.letter)}
-                            Tap where the word starts. "＋ board letter" adds a * for a letter you're crossing.
-                        {:else}
-                            Type a word, then tap the center star to place it.
+                    <div class="actions">
+                        <button disabled={!game.myTurn} onclick={() => game.pass()}>Skip my turn</button>
+                        <button
+                                disabled={!game.myTurn || swapLetters.length === 0}
+                                onclick={() => game.exchange(swapLetters)}
+                        >{swapLetters.length > 0 ? `Swap ${swapLetters.length} letter${swapLetters.length === 1 ? "" : "s"}` : "Swap letters"}</button>
+                        {#if canChallenge && game.challengeableMoverId}
+                            <button onclick={() => game.challengeWord()}>Challenge {game.playerName(game.challengeableMoverId)}'s word</button>
                         {/if}
-                    </p>
-                {/if}
-            </div>
-            <div class="actions">
-                {#if game.myTurn}
-                    <button onclick={() => game.pass()}>Skip my turn</button>
-                    <button
-                            disabled={game.input.length === 0}
-                            onclick={() => game.exchange([...game.input])}
-                    >{game.input.length > 0 ? `Swap ${game.input.length} letters` : "Swap letters"}</button>
-                {/if}
-                {#if canChallenge && game.challengeableMoverId}
-                    <button onclick={() => game.challengeWord()}>Challenge {game.playerName(game.challengeableMoverId)}'s word</button>
+                    </div>
                 {/if}
             </div>
         {/if}


### PR DESCRIPTION
## Summary

Panel polish from playtesting. Screenshots were shared for review before this PR; it stays a draft pending sign-off.

## The invisible drag tile

The floating drag tile from #7 rendered **off-screen** on the real page: the footer panel's `backdrop-filter` makes it the containing block for `position: fixed` descendants, so the tile's viewport coordinates were interpreted relative to the footer and it landed far below the visible screen. The earlier test only asserted the element existed — not where it was.

- The floating tile is now portaled to `document.body` (a Svelte action), immune to ancestor filter/transform containing blocks
- The test now asserts the tile's bounding box is **on-screen** mid-drag

## Input row redesign

The lower panel drops all inline instructions and gets a consistent layout:

- One row, all matching the input's height: **★** (inserts the `*` board-letter placeholder) on the left, the word input in the middle, **⌫** backspace on the right
- Below it: **Skip my turn** and **Swap N letters**, same height and styling, always present and disabled when it's not your turn (the challenge button joins that row contextually)
- Hint paragraphs removed

## Swap fix (caught in the screenshot)

The swap button counted `*` placeholders as swappable letters and would have sent `*` to the exchange endpoint. It now counts and sends only real letters.

## Testing

Full scripted browser suite passes, including the strengthened mid-drag assertion (floating tile must be within the viewport) and all prior checks. iPhone-sized screenshots of the new layout and mid-drag state were shared for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxiAE56JC7irn2xg1rZNqQ)_