### PR TITLE
Stop iOS double-tap zoom, keep rack arrangement, animate reorders

### DIFF
--- a/site/src/lib/Rack.svelte
+++ b/site/src/lib/Rack.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+    import { untrack } from "svelte";
+    import { flip } from "svelte/animate";
     import Tile from "$lib/Tile.svelte";
 
     type Props = {
@@ -11,28 +13,65 @@
 
     const { letters, letterPoints={}, input="", onTapLetter, onReorder }: Props = $props();
 
-    let unusedLetters = $state<string[]>([]);
-    let usedLetters = $state<string[]>([]);
+    // tiles carry stable ids so reorders can animate; reconcile against the
+    // letters prop, reusing ids for letters still on the rack
+    let tiles = $state<{ id: number; letter: string }[]>([]);
+    let nextId = 0;
 
     $effect(() => {
-        let nextUnusedLetters = [...letters];
-        let nextUsedLetters = [];
+        const incoming = letters;
+        untrack(() => {
+            const pool = [...tiles];
+            tiles = incoming.map((letter) => {
+                const index = pool.findIndex(tile => tile.letter === letter);
+                if (index !== -1) {
+                    return pool.splice(index, 1)[0];
+                }
+                return { id: nextId++, letter };
+            });
+        });
+    });
 
-        for (let letter of input) {
-            let index = nextUnusedLetters.indexOf(letter);
-            if (index !== -1) {
-                nextUnusedLetters.splice(index, 1);
-                nextUsedLetters.push(letter);
+    // the tiles the player explicitly tapped into the word, so duplicates
+    // highlight the copy that was actually touched
+    let tappedIds = $state<number[]>([]);
+
+    $effect(() => {
+        if (input === "") {
+            tappedIds = [];
+        }
+    });
+
+    // tiles spent on the current word, highlighted in place: tapped tiles
+    // first, then first-match for typed letters
+    let usedIds = $derived.by(() => {
+        const ids = new Set<number>();
+        const needed = new Map<string, number>();
+        for (const letter of input) {
+            needed.set(letter, (needed.get(letter) ?? 0) + 1);
+        }
+
+        for (const id of tappedIds) {
+            const tile = tiles.find(candidate => candidate.id === id);
+            if (tile && (needed.get(tile.letter) ?? 0) > 0) {
+                ids.add(tile.id);
+                needed.set(tile.letter, (needed.get(tile.letter) ?? 0) - 1);
             }
         }
 
-        unusedLetters = nextUnusedLetters;
-        usedLetters = nextUsedLetters;
-    })
+        for (const tile of tiles) {
+            if (!ids.has(tile.id) && (needed.get(tile.letter) ?? 0) > 0) {
+                ids.add(tile.id);
+                needed.set(tile.letter, (needed.get(tile.letter) ?? 0) - 1);
+            }
+        }
+
+        return ids;
+    });
 
     let listElement: HTMLUListElement;
 
-    // index within unusedLetters of the tile being dragged, if any
+    // index within tiles of the one being dragged, if any
     let dragIndex = $state<number | null>(null);
     let dragMoved = $state(false);
     let dragStart = { x: 0, y: 0 };
@@ -85,27 +124,30 @@
         }
         if (!dragMoved) return;
 
-        const target = Math.max(0, Math.min(
-            unusedLetters.length - 1,
-            nearestDisplayIndex(e) - usedLetters.length,
-        ));
-
+        const target = Math.max(0, Math.min(tiles.length - 1, nearestDisplayIndex(e)));
         if (target !== dragIndex) {
-            const next = [...unusedLetters];
+            const next = [...tiles];
             const [moved] = next.splice(dragIndex, 1);
             next.splice(target, 0, moved);
-            unusedLetters = next;
+            tiles = next;
             dragIndex = target;
         }
     }
 
     function handlePointerUp() {
         if (dragIndex === null) return;
+        const tile = tiles[dragIndex];
 
         if (dragMoved) {
-            onReorder?.([...usedLetters, ...unusedLetters]);
-        } else {
-            onTapLetter?.(unusedLetters[dragIndex], false);
+            onReorder?.(tiles.map(t => t.letter));
+        } else if (tile) {
+            const used = usedIds.has(tile.id);
+            if (used) {
+                tappedIds = tappedIds.filter(id => id !== tile.id);
+            } else {
+                tappedIds = [...tappedIds, tile.id];
+            }
+            onTapLetter?.(tile.letter, used);
         }
 
         dragIndex = null;
@@ -164,26 +206,22 @@
 </style>
 
 <ul bind:this={listElement}>
-    {#each usedLetters as letter, index (index)}
-        <li onpointerup={() => onTapLetter?.(letter, true)}>
-            <Tile cellSize={50} letter={letter} x={0} y={0} points={letterPoints[letter]} selected />
-        </li>
-    {/each}
-    {#each unusedLetters as letter, index (index)}
+    {#each tiles as tile, index (tile.id)}
         <li
-                class:dragging={dragIndex === index}
+                animate:flip={{ duration: 150 }}
+                class:dragging={dragIndex === index && dragMoved}
                 onpointerdown={(e) => handlePointerDown(e, index)}
                 onpointermove={handlePointerMove}
                 onpointerup={handlePointerUp}
                 onpointercancel={handlePointerCancel}
         >
-            <Tile cellSize={50} letter={letter} x={0} y={0} points={letterPoints[letter]} />
+            <Tile cellSize={50} letter={tile.letter} x={0} y={0} points={letterPoints[tile.letter]} selected={usedIds.has(tile.id)} />
         </li>
     {/each}
 </ul>
 
-{#if dragIndex !== null && dragMoved}
+{#if dragIndex !== null && dragMoved && tiles[dragIndex]}
     <div class="floating" use:portal style="left: {dragPosition.x - 25}px; top: {dragPosition.y - dragLift}px;">
-        <Tile cellSize={50} letter={unusedLetters[dragIndex]} x={0} y={0} points={letterPoints[unusedLetters[dragIndex]]} selected />
+        <Tile cellSize={50} letter={tiles[dragIndex].letter} x={0} y={0} points={letterPoints[tiles[dragIndex].letter]} selected />
     </div>
 {/if}

--- a/site/src/lib/game.svelte.ts
+++ b/site/src/lib/game.svelte.ts
@@ -63,22 +63,22 @@ export  class GameController {
     }
 
     set rack(value: string[]) {
-        // sort by points
-        value.sort((a, b) => {
-            return this.letterPoints[b] - this.letterPoints[a];
-        });
-
         this.#rack = value;
-        this.sortedRack = value;
-    }
 
-    updateSortedRack() {
-        this.sortedRack = this.sortedRack.sort((a, b) => {
-            // stable sort where letters not in the rack are sorted to the end
-            // adding 1 makes sure all letters in the word are sorted in placement order (including index 0)
-            // || 999 replaces all -1 (now 0) values with 999 so they go to the end
-            return (this.input.indexOf(a)+1 || 999) - (this.input.indexOf(b)+1 || 999);
-        });
+        // preserve the player's arrangement: tiles they still hold keep
+        // their order, new draws join at the end (highest points first)
+        const remaining = [...value];
+        const kept: string[] = [];
+        for (const letter of this.sortedRack) {
+            const index = remaining.indexOf(letter);
+            if (index !== -1) {
+                kept.push(letter);
+                remaining.splice(index, 1);
+            }
+        }
+        remaining.sort((a, b) => (this.letterPoints[b] ?? 0) - (this.letterPoints[a] ?? 0));
+
+        this.sortedRack = [...kept, ...remaining];
     }
 
     sortedRack = $state<string[]>([]);
@@ -91,7 +91,6 @@ export  class GameController {
 
     set input(value: string) {
         this.#input = value;
-        this.updateSortedRack();
     }
 
     started = $state<boolean>(false);

--- a/site/src/routes/play/+page.svelte
+++ b/site/src/routes/play/+page.svelte
@@ -163,7 +163,14 @@
 </svelte:head>
 
 <style>
+    /* iOS zooms the page on rapid double-taps; declare taps on controls as
+       plain taps so backspacing twice doesn't zoom */
+    button, input {
+        touch-action: manipulation;
+    }
+
     .panel {
+        touch-action: manipulation;
         display: flex;
         flex-direction: column;
         align-items: center;


### PR DESCRIPTION
## Summary

Three refinements from playtesting:

## iOS double-tap zoom

Tapping backspace (or any panel button) twice in quick succession triggered Safari's double-tap page zoom — the viewport meta can't disable it. `touch-action: manipulation` on the panel and its controls declares taps as plain taps; as a bonus it removes Safari's ~350ms tap delay so buttons feel snappier. Board pinch/pan is untouched.

## The rack stays how you arrange it

Now that tiles can be hand-arranged, the auto-sorting fought the player:

- Letters used in the word **highlight in place** instead of jumping to the front of the rack
- Rack refills keep held tiles in their arranged order and append only the new draws (sorted by points) at the end — no more full re-sort wiping your layout
- With duplicate letters, the copy you actually **tapped** is the one that highlights and toggles back off (tap-tracking with a first-match fallback for typed letters)

## Smooth drag animation

Tiles carry stable identities so reordering animates with FLIP transitions (150ms) — slots glide aside as the dragged tile moves through the rack instead of teleporting. The floating copy under your finger is unchanged.

## Testing

Full scripted browser suite passes, including a new toggle assertion that the exact tapped duplicate is the one that untoggles. The suite caught the duplicate-letter mismatch during development (tapping the last `O` highlighted the first `O`), which drove the tap-tracking design.